### PR TITLE
feat: create redis client features inside the dashboard and restructure the menus

### DIFF
--- a/deploy/compose/docker-compose.dev.yml
+++ b/deploy/compose/docker-compose.dev.yml
@@ -15,6 +15,21 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    container_name: nias-redis-dev
+    restart: unless-stopped
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   # Backend server with hot reload
   server:
     build:
@@ -51,3 +66,9 @@ services:
       - VITE_API_URL=http://localhost:8080
       - VITE_API_PROXY_TARGET=http://server:8080
     command: ["sh", "-c", "bun install && bun run dev --host 0.0.0.0"]
+
+volumes:
+  postgres-data:
+    driver: local
+  redis-data:
+    driver: local

--- a/server/handlers/connections.go
+++ b/server/handlers/connections.go
@@ -25,6 +25,7 @@ var allowedDrivers = map[string]bool{
 	"mysql":    true,
 	"mariadb":  true, // alias → uses MySQL driver
 	"mssql":    true,
+	"redis":    true,
 }
 
 // encryptionKey for credential encryption (should be set from environment)
@@ -150,7 +151,7 @@ type ConnectionInput struct {
 func validateConnectionInput(in *ConnectionInput) error {
 	// Validate driver
 	if !allowedDrivers[in.Driver] {
-		return fmt.Errorf("invalid driver: must be postgres, mysql, mariadb, or mssql")
+		return fmt.Errorf("invalid driver: must be postgres, mysql, mariadb, mssql, or redis")
 	}
 
 	// Validate port
@@ -191,6 +192,8 @@ func isValidHostname(host string) bool {
 
 func buildDSN(in ConnectionInput) (string, error) {
 	switch in.Driver {
+	case "redis":
+		return "", fmt.Errorf("redis does not use SQL DSN")
 	case "postgres":
 		sslMode := "disable"
 		if in.SSL {
@@ -394,7 +397,7 @@ func CreateConnection() http.HandlerFunc {
 		var id int64
 		var c Connection
 		var sslV int
-		
+
 		// PostgreSQL and MySQL support RETURNING clause
 		if appdb.IsPostgreSQL() || appdb.IsMySQL() {
 			query := `INSERT INTO connections (name, driver, host, port, database, username, password, ssl, tags,
@@ -444,14 +447,14 @@ func CreateConnection() http.HandlerFunc {
 func GetConnection() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		
+
 		idStr := strings.TrimPrefix(r.URL.Path, "/api/connections/")
 		connID, err := strconv.ParseInt(idStr, 10, 64)
 		if err != nil {
 			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
 			return
 		}
-		
+
 		// Get current user info
 		userIDStr := r.Header.Get("X-User-ID")
 		userRole := r.Header.Get("X-User-Role")
@@ -459,37 +462,37 @@ func GetConnection() http.HandlerFunc {
 		if userIDStr != "" {
 			userID, _ = strconv.ParseInt(userIDStr, 10, 64)
 		}
-		
+
 		// Fetch connection
 		var c Connection
 		var ssl int
 		var encPassword, encSSHPassword, encSSHKey string
-		
+
 		query := appdb.ConvertQuery(`SELECT id, name, driver, COALESCE(host,''), COALESCE(port,0), database,
 			COALESCE(username,''), password, ssl, COALESCE(tags,''),
 			COALESCE(ssh_host,''), COALESCE(ssh_port,22), COALESCE(ssh_user,''), ssh_password, ssh_key,
 			folder_id, COALESCE(visibility,'shared'), COALESCE(owner_id,0), created_at
 			FROM connections WHERE id=?`)
-		
+
 		err = appdb.DB.QueryRow(query, connID).Scan(
 			&c.ID, &c.Name, &c.Driver, &c.Host, &c.Port, &c.Database,
 			&c.Username, &encPassword, &ssl, &c.Tags,
 			&c.SSHHost, &c.SSHPort, &c.SSHUser, &encSSHPassword, &encSSHKey,
 			&c.FolderID, &c.Visibility, &c.OwnerID, &c.CreatedAt)
-		
+
 		if err != nil {
 			http.Error(w, `{"error":"connection not found"}`, http.StatusNotFound)
 			return
 		}
-		
+
 		c.SSL = ssl == 1
-		
+
 		// Check permission
 		if isAuthEnabled() && userRole != "admin" && c.OwnerID != userID && c.Visibility != "shared" {
 			http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
 			return
 		}
-		
+
 		// Mask passwords (show bullets for security)
 		if encPassword != "" {
 			c.Password = "••••••••"
@@ -500,7 +503,7 @@ func GetConnection() http.HandlerFunc {
 		if encSSHKey != "" {
 			c.SSHKey = "••••••••"
 		}
-		
+
 		json.NewEncoder(w).Encode(c)
 	}
 }
@@ -508,7 +511,7 @@ func GetConnection() http.HandlerFunc {
 func UpdateConnection() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		
+
 		// Get connection ID from URL
 		idStr := strings.TrimPrefix(r.URL.Path, "/api/connections/")
 		connID, err := strconv.ParseInt(idStr, 10, 64)
@@ -516,7 +519,7 @@ func UpdateConnection() http.HandlerFunc {
 			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
 			return
 		}
-		
+
 		// Check if connection exists and user has permission
 		var existingOwnerID int64
 		err = appdb.DB.QueryRow(appdb.ConvertQuery(`SELECT owner_id FROM connections WHERE id = ?`), connID).Scan(&existingOwnerID)
@@ -524,7 +527,7 @@ func UpdateConnection() http.HandlerFunc {
 			http.Error(w, `{"error":"connection not found"}`, http.StatusNotFound)
 			return
 		}
-		
+
 		// Get current user info
 		userIDStr := r.Header.Get("X-User-ID")
 		userRole := r.Header.Get("X-User-Role")
@@ -532,34 +535,34 @@ func UpdateConnection() http.HandlerFunc {
 		if userIDStr != "" {
 			userID, _ = strconv.ParseInt(userIDStr, 10, 64)
 		}
-		
+
 		// Check permission: must be owner or admin
 		if isAuthEnabled() && userRole != "admin" && existingOwnerID != userID {
 			http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
 			return
 		}
-		
+
 		var in ConnectionInput
 		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
 			http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
 			return
 		}
-		
+
 		if in.Name == "" || in.Driver == "" {
 			http.Error(w, `{"error":"name and driver are required"}`, http.StatusBadRequest)
 			return
 		}
-		
+
 		// Validate input
 		if err := validateConnectionInput(&in); err != nil {
 			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
 			return
 		}
-		
+
 		if in.Visibility == "" {
 			in.Visibility = "shared"
 		}
-		
+
 		// Handle password: if empty or masked, keep existing
 		var encPassword string
 		if in.Password != "" && !strings.Contains(in.Password, "•") {
@@ -572,7 +575,7 @@ func UpdateConnection() http.HandlerFunc {
 			// Keep existing password
 			appdb.DB.QueryRow(appdb.ConvertQuery(`SELECT password FROM connections WHERE id = ?`), connID).Scan(&encPassword)
 		}
-		
+
 		// Handle SSH credentials
 		var encSSHPassword, encSSHKey string
 		if in.SSHPassword != "" && !strings.Contains(in.SSHPassword, "•") {
@@ -584,7 +587,7 @@ func UpdateConnection() http.HandlerFunc {
 		} else {
 			appdb.DB.QueryRow(appdb.ConvertQuery(`SELECT ssh_password FROM connections WHERE id = ?`), connID).Scan(&encSSHPassword)
 		}
-		
+
 		if in.SSHKey != "" && !strings.Contains(in.SSHKey, "•") {
 			encSSHKey, err = encryptCredential(in.SSHKey)
 			if err != nil {
@@ -594,18 +597,18 @@ func UpdateConnection() http.HandlerFunc {
 		} else {
 			appdb.DB.QueryRow(appdb.ConvertQuery(`SELECT ssh_key FROM connections WHERE id = ?`), connID).Scan(&encSSHKey)
 		}
-		
+
 		ssl := 0
 		if in.SSL {
 			ssl = 1
 		}
-		
+
 		// Update connection
 		query := appdb.ConvertQuery(`UPDATE connections SET 
 			name=?, driver=?, host=?, port=?, database=?, username=?, password=?, ssl=?, tags=?,
 			ssh_host=?, ssh_port=?, ssh_user=?, ssh_password=?, ssh_key=?, folder_id=?, visibility=?
 			WHERE id=?`)
-		
+
 		_, err = appdb.DB.Exec(query,
 			in.Name, in.Driver, in.Host, in.Port, in.Database, in.Username, encPassword, ssl, in.Tags,
 			in.SSHHost, in.SSHPort, in.SSHUser, encSSHPassword, encSSHKey, in.FolderID, in.Visibility, connID,
@@ -614,10 +617,10 @@ func UpdateConnection() http.HandlerFunc {
 			http.Error(w, `{"error":"failed to update connection"}`, http.StatusInternalServerError)
 			return
 		}
-		
+
 		// Evict from pool to force reconnect with new credentials
 		EvictFromPool(connID)
-		
+
 		// Fetch updated connection
 		var c Connection
 		var sslV int
@@ -632,7 +635,7 @@ func UpdateConnection() http.HandlerFunc {
 			&c.SSHHost, &c.SSHPort, &c.SSHUser,
 			&c.FolderID, &c.Visibility, &c.OwnerID, &c.CreatedAt)
 		c.SSL = sslV == 1
-		
+
 		json.NewEncoder(w).Encode(c)
 	}
 }
@@ -664,7 +667,7 @@ func DeleteConnection() http.HandlerFunc {
 func UpdateConnectionFolder() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		
+
 		// Extract connection ID from URL
 		path := strings.TrimPrefix(r.URL.Path, "/api/connections/")
 		parts := strings.Split(path, "/")
@@ -672,7 +675,7 @@ func UpdateConnectionFolder() http.HandlerFunc {
 			http.Error(w, `{"error":"invalid endpoint"}`, http.StatusBadRequest)
 			return
 		}
-		
+
 		id, err := strconv.ParseInt(parts[0], 10, 64)
 		if err != nil {
 			http.Error(w, `{"error":"invalid id"}`, http.StatusBadRequest)
@@ -720,7 +723,7 @@ func UpdateConnectionFolder() http.HandlerFunc {
 func UpdateConnectionVisibility() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		
+
 		// Extract connection ID from URL
 		path := strings.TrimPrefix(r.URL.Path, "/api/connections/")
 		parts := strings.Split(path, "/")
@@ -728,7 +731,7 @@ func UpdateConnectionVisibility() http.HandlerFunc {
 			http.Error(w, `{"error":"invalid endpoint"}`, http.StatusBadRequest)
 			return
 		}
-		
+
 		id, err := strconv.ParseInt(parts[0], 10, 64)
 		if err != nil {
 			http.Error(w, `{"error":"invalid id"}`, http.StatusBadRequest)
@@ -798,6 +801,15 @@ func TestConnection() http.HandlerFunc {
 		// Validate input
 		if err := validateConnectionInput(&in); err != nil {
 			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		if in.Driver == "redis" {
+			if err := testRedisInput(r.Context(), in); err != nil {
+				http.Error(w, jsonError("connection failed: "+err.Error()), http.StatusBadGateway)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]string{"message": "Connection successful"})
 			return
 		}
 

--- a/server/handlers/redis.go
+++ b/server/handlers/redis.go
@@ -1,0 +1,1240 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	appdb "github.com/anveesa/nias/db"
+)
+
+type redisClient struct {
+	address  string
+	username string
+	password string
+	db       int
+	tls      bool
+	timeout  time.Duration
+}
+
+type redisKeySummary struct {
+	Key  string `json:"key"`
+	Type string `json:"type"`
+	TTL  int64  `json:"ttl"`
+}
+
+type redisKeysResponse struct {
+	Cursor string            `json:"cursor"`
+	Keys   []redisKeySummary `json:"keys"`
+}
+
+type redisValueResponse struct {
+	Key       string `json:"key"`
+	Type      string `json:"type"`
+	TTL       int64  `json:"ttl"`
+	Length    int64  `json:"length,omitempty"`
+	Value     any    `json:"value"`
+	Truncated bool   `json:"truncated"`
+}
+
+type redisWriteRequest struct {
+	Key   string          `json:"key"`
+	Type  string          `json:"type"`
+	Value json.RawMessage `json:"value"`
+	TTL   int64           `json:"ttl"`
+	DB    *int            `json:"db"`
+}
+
+type redisRenameRequest struct {
+	OldKey string `json:"old_key"`
+	NewKey string `json:"new_key"`
+	DB     *int   `json:"db"`
+}
+
+type redisCommandRequest struct {
+	Command string `json:"command"`
+	DB      *int   `json:"db"`
+}
+
+type redisScriptRequest struct {
+	Script string `json:"script"`
+	DB     *int   `json:"db"`
+}
+
+type redisScriptResult struct {
+	Line    int    `json:"line"`
+	Command string `json:"command"`
+	Result  any    `json:"result,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+type redisMoveRequest struct {
+	Key       string `json:"key"`
+	FromDB    int    `json:"from_db"`
+	ToDB      int    `json:"to_db"`
+	Overwrite bool   `json:"overwrite"`
+}
+
+type redisZSetItem struct {
+	Member string  `json:"member"`
+	Score  float64 `json:"score"`
+}
+
+func testRedisInput(ctx context.Context, in ConnectionInput) error {
+	client, err := newRedisClientFromInput(in)
+	if err != nil {
+		return err
+	}
+	resp, err := client.command(ctx, "PING")
+	if err != nil {
+		return err
+	}
+	pong, ok := resp.(string)
+	if !ok || strings.ToUpper(pong) != "PONG" {
+		return fmt.Errorf("unexpected PING response: %v", resp)
+	}
+	return nil
+}
+
+func RedisKeys() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		client, connName, err := openRedisClient(connID, redisDBFromRequest(r))
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		pattern := strings.TrimSpace(r.URL.Query().Get("pattern"))
+		if pattern == "" {
+			pattern = "*"
+		}
+		cursor := strings.TrimSpace(r.URL.Query().Get("cursor"))
+		if cursor == "" {
+			cursor = "0"
+		}
+		count := queryInt(r, "count", 100, 10, 500)
+
+		resp, err := client.command(r.Context(), "SCAN", cursor, "MATCH", pattern, "COUNT", strconv.Itoa(count))
+		if err != nil {
+			http.Error(w, jsonError("redis scan failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+		values, ok := resp.([]any)
+		if !ok || len(values) != 2 {
+			http.Error(w, jsonError("unexpected redis scan response"), http.StatusBadGateway)
+			return
+		}
+		nextCursor, _ := values[0].(string)
+		rawKeys, _ := values[1].([]any)
+
+		keys := make([]redisKeySummary, 0, len(rawKeys))
+		for _, raw := range rawKeys {
+			key, ok := raw.(string)
+			if !ok {
+				continue
+			}
+			keyType := "unknown"
+			if t, err := client.command(r.Context(), "TYPE", key); err == nil {
+				if s, ok := t.(string); ok {
+					keyType = s
+				}
+			}
+			ttl := int64(-2)
+			if t, err := client.command(r.Context(), "TTL", key); err == nil {
+				if n, ok := t.(int64); ok {
+					ttl = n
+				}
+			}
+			keys = append(keys, redisKeySummary{Key: key, Type: keyType, TTL: ttl})
+		}
+
+		writeRedisAudit(r, "redis_scan_keys", connID, connName, pattern, "")
+		json.NewEncoder(w).Encode(redisKeysResponse{Cursor: nextCursor, Keys: keys})
+	}
+}
+
+func RedisPing() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+
+		client, connName, err := openRedisClient(connID, redisDBFromRequest(r))
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+		start := time.Now()
+		resp, err := client.command(r.Context(), "PING")
+		if err != nil {
+			writeRedisAudit(r, "redis_ping", connID, connName, "", err.Error())
+			http.Error(w, jsonError("redis ping failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+		pong, ok := resp.(string)
+		if !ok || strings.ToUpper(pong) != "PONG" {
+			errMsg := fmt.Sprintf("unexpected PING response: %v", resp)
+			writeRedisAudit(r, "redis_ping", connID, connName, "", errMsg)
+			http.Error(w, jsonError("redis ping failed: "+errMsg), http.StatusBadGateway)
+			return
+		}
+		writeRedisAudit(r, "redis_ping", connID, connName, "", "")
+		json.NewEncoder(w).Encode(map[string]any{
+			"status":     "ok",
+			"message":    "PONG",
+			"latency_ms": time.Since(start).Milliseconds(),
+		})
+	}
+}
+
+func RedisKeyValue() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		key := r.URL.Query().Get("key")
+		if key == "" {
+			http.Error(w, `{"error":"key is required"}`, http.StatusBadRequest)
+			return
+		}
+		client, connName, err := openRedisClient(connID, redisDBFromRequest(r))
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		result, err := readRedisValue(r.Context(), client, key)
+		if err != nil {
+			http.Error(w, jsonError("redis read failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+		writeRedisAudit(r, "redis_read_key", connID, connName, key, "")
+		json.NewEncoder(w).Encode(result)
+	}
+}
+
+func RedisWriteKey() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		var payload redisWriteRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		payload.Key = strings.TrimSpace(payload.Key)
+		payload.Type = strings.ToLower(strings.TrimSpace(payload.Type))
+		if payload.Key == "" {
+			http.Error(w, `{"error":"key is required"}`, http.StatusBadRequest)
+			return
+		}
+		if err := validateRedisKeyType(payload.Type); err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		client, connName, err := openRedisClient(connID, payload.DB)
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+		if err := writeRedisValue(r.Context(), client, payload); err != nil {
+			writeRedisAudit(r, "redis_write_key", connID, connName, payload.Key, err.Error())
+			http.Error(w, jsonError("redis write failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+		writeRedisAudit(r, "redis_write_key", connID, connName, payload.Key, "")
+		json.NewEncoder(w).Encode(map[string]string{"message": "Redis key saved"})
+	}
+}
+
+func RedisDeleteKey() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		key := r.URL.Query().Get("key")
+		if key == "" {
+			http.Error(w, `{"error":"key is required"}`, http.StatusBadRequest)
+			return
+		}
+		client, connName, err := openRedisClient(connID, redisDBFromRequest(r))
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+		if _, err := client.command(r.Context(), "DEL", key); err != nil {
+			writeRedisAudit(r, "redis_delete_key", connID, connName, key, err.Error())
+			http.Error(w, jsonError("redis delete failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+		writeRedisAudit(r, "redis_delete_key", connID, connName, key, "")
+		json.NewEncoder(w).Encode(map[string]string{"message": "Redis key deleted"})
+	}
+}
+
+func RedisRenameKey() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		var payload redisRenameRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		payload.OldKey = strings.TrimSpace(payload.OldKey)
+		payload.NewKey = strings.TrimSpace(payload.NewKey)
+		if payload.OldKey == "" || payload.NewKey == "" {
+			http.Error(w, `{"error":"old_key and new_key are required"}`, http.StatusBadRequest)
+			return
+		}
+		client, connName, err := openRedisClient(connID, payload.DB)
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+		result, err := client.command(r.Context(), "RENAMENX", payload.OldKey, payload.NewKey)
+		if err != nil {
+			writeRedisAudit(r, "redis_rename_key", connID, connName, payload.OldKey, err.Error())
+			http.Error(w, jsonError("redis rename failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+		if renamed, ok := result.(int64); ok && renamed == 0 {
+			http.Error(w, jsonError("redis rename failed: target key already exists"), http.StatusConflict)
+			return
+		}
+		writeRedisAudit(r, "redis_rename_key", connID, connName, payload.OldKey+" -> "+payload.NewKey, "")
+		json.NewEncoder(w).Encode(map[string]string{"message": "Redis key renamed"})
+	}
+}
+
+func RedisCommand() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		var payload redisCommandRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		args, err := parseRedisCommand(payload.Command)
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+		if err := validateRedisCommand(args); err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusForbidden)
+			return
+		}
+		client, connName, err := openRedisClient(connID, payload.DB)
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+		result, err := client.command(r.Context(), args...)
+		if err != nil {
+			writeRedisAudit(r, "redis_command", connID, connName, args[0], err.Error())
+			http.Error(w, jsonError("redis command failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+		writeRedisAudit(r, "redis_command", connID, connName, args[0], "")
+		json.NewEncoder(w).Encode(map[string]any{"result": result})
+	}
+}
+
+func RedisGenerateScript() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		key := strings.TrimSpace(r.URL.Query().Get("key"))
+		pattern := strings.TrimSpace(r.URL.Query().Get("pattern"))
+		if key == "" && pattern == "" {
+			http.Error(w, `{"error":"key or pattern is required"}`, http.StatusBadRequest)
+			return
+		}
+		client, connName, err := openRedisClient(connID, redisDBFromRequest(r))
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		keys := []string{key}
+		if pattern != "" {
+			keys, err = scanRedisKeys(r.Context(), client, pattern, 200)
+			if err != nil {
+				http.Error(w, jsonError("redis scan failed: "+err.Error()), http.StatusBadGateway)
+				return
+			}
+		}
+		var lines []string
+		for _, k := range keys {
+			if strings.TrimSpace(k) == "" {
+				continue
+			}
+			value, err := readRedisValue(r.Context(), client, k)
+			if err != nil {
+				continue
+			}
+			lines = append(lines, redisScriptForValue(value)...)
+		}
+		writeRedisAudit(r, "redis_generate_script", connID, connName, key+pattern, "")
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = w.Write([]byte(strings.Join(lines, "\n")))
+	}
+}
+
+func RedisExecuteScript() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		var payload redisScriptRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		commands, err := parseRedisScript(payload.Script, 100)
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+		client, connName, err := openRedisClient(connID, payload.DB)
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		results := make([]redisScriptResult, 0, len(commands))
+		for _, command := range commands {
+			args, err := parseRedisCommand(command.text)
+			if err != nil {
+				results = append(results, redisScriptResult{Line: command.line, Command: command.text, Error: err.Error()})
+				break
+			}
+			if err := validateRedisCommand(args); err != nil {
+				results = append(results, redisScriptResult{Line: command.line, Command: command.text, Error: err.Error()})
+				break
+			}
+			result, err := client.command(r.Context(), args...)
+			if err != nil {
+				results = append(results, redisScriptResult{Line: command.line, Command: command.text, Error: err.Error()})
+				break
+			}
+			results = append(results, redisScriptResult{Line: command.line, Command: command.text, Result: result})
+		}
+		writeRedisAudit(r, "redis_execute_script", connID, connName, strconv.Itoa(len(results))+" commands", "")
+		json.NewEncoder(w).Encode(map[string]any{"results": results})
+	}
+}
+
+func RedisMoveKey() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		var payload redisMoveRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		payload.Key = strings.TrimSpace(payload.Key)
+		if payload.Key == "" {
+			http.Error(w, `{"error":"key is required"}`, http.StatusBadRequest)
+			return
+		}
+		if payload.FromDB < 0 || payload.ToDB < 0 {
+			http.Error(w, `{"error":"db indexes must be non-negative"}`, http.StatusBadRequest)
+			return
+		}
+		if payload.FromDB == payload.ToDB {
+			http.Error(w, `{"error":"target db must be different"}`, http.StatusBadRequest)
+			return
+		}
+
+		client, connName, err := openRedisClient(connID, &payload.FromDB)
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+		if payload.Overwrite {
+			target, _, err := openRedisClient(connID, &payload.ToDB)
+			if err != nil {
+				http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+				return
+			}
+			if _, err := target.command(r.Context(), "DEL", payload.Key); err != nil {
+				http.Error(w, jsonError("redis target delete failed: "+err.Error()), http.StatusBadGateway)
+				return
+			}
+		}
+		result, err := client.command(r.Context(), "MOVE", payload.Key, strconv.Itoa(payload.ToDB))
+		if err != nil {
+			writeRedisAudit(r, "redis_move_key", connID, connName, payload.Key, err.Error())
+			http.Error(w, jsonError("redis move failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+		if moved, ok := result.(int64); ok && moved == 0 {
+			http.Error(w, jsonError("redis move failed: target key already exists or source key is missing"), http.StatusConflict)
+			return
+		}
+		writeRedisAudit(r, "redis_move_key", connID, connName, fmt.Sprintf("%s db%d -> db%d", payload.Key, payload.FromDB, payload.ToDB), "")
+		json.NewEncoder(w).Encode(map[string]string{"message": "Redis key moved"})
+	}
+}
+
+func readRedisValue(ctx context.Context, client *redisClient, key string) (redisValueResponse, error) {
+	resp := redisValueResponse{Key: key, Type: "none", TTL: -2}
+	if ttl, err := client.command(ctx, "TTL", key); err == nil {
+		if n, ok := ttl.(int64); ok {
+			resp.TTL = n
+		}
+	}
+	rawType, err := client.command(ctx, "TYPE", key)
+	if err != nil {
+		return resp, err
+	}
+	keyType, _ := rawType.(string)
+	resp.Type = keyType
+
+	switch normalizeRedisType(keyType) {
+	case "string":
+		value, err := client.command(ctx, "GET", key)
+		if err != nil {
+			return resp, err
+		}
+		if s, ok := value.(string); ok {
+			resp.Value = s
+			resp.Length = int64(len(s))
+		}
+	case "hash":
+		length, _ := redisInt(client.command(ctx, "HLEN", key))
+		items, err := client.command(ctx, "HGETALL", key)
+		if err != nil {
+			return resp, err
+		}
+		resp.Length = length
+		resp.Value = stringPairsToMap(items)
+	case "list":
+		length, _ := redisInt(client.command(ctx, "LLEN", key))
+		items, err := client.command(ctx, "LRANGE", key, "0", "99")
+		if err != nil {
+			return resp, err
+		}
+		resp.Length = length
+		resp.Truncated = length > 100
+		resp.Value = anySliceToStrings(items)
+	case "set":
+		length, _ := redisInt(client.command(ctx, "SCARD", key))
+		items, err := client.command(ctx, "SSCAN", key, "0", "COUNT", "100")
+		if err != nil {
+			return resp, err
+		}
+		resp.Length = length
+		resp.Value = scanValues(items)
+		resp.Truncated = length > 100
+	case "zset":
+		length, _ := redisInt(client.command(ctx, "ZCARD", key))
+		items, err := client.command(ctx, "ZRANGE", key, "0", "99", "WITHSCORES")
+		if err != nil {
+			return resp, err
+		}
+		resp.Length = length
+		resp.Value = zsetPairs(items)
+		resp.Truncated = length > 100
+	case "stream":
+		length, _ := redisInt(client.command(ctx, "XLEN", key))
+		items, err := client.command(ctx, "XRANGE", key, "-", "+", "COUNT", "50")
+		if err != nil {
+			return resp, err
+		}
+		resp.Length = length
+		resp.Value = streamEntries(items)
+		resp.Truncated = length > 50
+	case "json":
+		value, err := client.command(ctx, "JSON.GET", key)
+		if err != nil {
+			return resp, err
+		}
+		if s, ok := value.(string); ok {
+			resp.Type = "json"
+			resp.Length = int64(len(s))
+			var decoded any
+			if json.Unmarshal([]byte(s), &decoded) == nil {
+				resp.Value = decoded
+			} else {
+				resp.Value = s
+			}
+		}
+	default:
+		resp.Value = nil
+	}
+	return resp, nil
+}
+
+func validateRedisKeyType(keyType string) error {
+	switch keyType {
+	case "string", "hash", "list", "set", "zset", "stream", "json":
+		return nil
+	default:
+		return fmt.Errorf("unsupported redis type: must be string, hash, list, set, zset, stream, or json")
+	}
+}
+
+func writeRedisValue(ctx context.Context, client *redisClient, payload redisWriteRequest) error {
+	if _, err := client.command(ctx, "DEL", payload.Key); err != nil {
+		return err
+	}
+	switch payload.Type {
+	case "json":
+		if !json.Valid(payload.Value) {
+			return fmt.Errorf("json value must be valid JSON")
+		}
+		if _, err := client.command(ctx, "JSON.SET", payload.Key, "$", string(payload.Value)); err != nil {
+			return err
+		}
+	case "string":
+		var value string
+		if err := json.Unmarshal(payload.Value, &value); err != nil {
+			return fmt.Errorf("string value must be a JSON string")
+		}
+		if _, err := client.command(ctx, "SET", payload.Key, value); err != nil {
+			return err
+		}
+	case "hash":
+		values := map[string]string{}
+		if err := json.Unmarshal(payload.Value, &values); err != nil {
+			return fmt.Errorf("hash value must be a JSON object")
+		}
+		if len(values) == 0 {
+			return fmt.Errorf("hash must contain at least one field")
+		}
+		args := []string{"HSET", payload.Key}
+		for field, value := range values {
+			args = append(args, field, value)
+		}
+		if _, err := client.command(ctx, args...); err != nil {
+			return err
+		}
+	case "list":
+		values, err := stringListFromRaw(payload.Value, "list")
+		if err != nil {
+			return err
+		}
+		args := append([]string{"RPUSH", payload.Key}, values...)
+		if _, err := client.command(ctx, args...); err != nil {
+			return err
+		}
+	case "set":
+		values, err := stringListFromRaw(payload.Value, "set")
+		if err != nil {
+			return err
+		}
+		args := append([]string{"SADD", payload.Key}, values...)
+		if _, err := client.command(ctx, args...); err != nil {
+			return err
+		}
+	case "zset":
+		var values []redisZSetItem
+		if err := json.Unmarshal(payload.Value, &values); err != nil {
+			return fmt.Errorf("zset value must be a JSON array of {member, score}")
+		}
+		if len(values) == 0 {
+			return fmt.Errorf("zset must contain at least one member")
+		}
+		args := []string{"ZADD", payload.Key}
+		for _, item := range values {
+			args = append(args, strconv.FormatFloat(item.Score, 'f', -1, 64), item.Member)
+		}
+		if _, err := client.command(ctx, args...); err != nil {
+			return err
+		}
+	case "stream":
+		values := map[string]string{}
+		if err := json.Unmarshal(payload.Value, &values); err != nil {
+			return fmt.Errorf("stream value must be a JSON object")
+		}
+		if len(values) == 0 {
+			return fmt.Errorf("stream entry must contain at least one field")
+		}
+		args := []string{"XADD", payload.Key, "*"}
+		for field, value := range values {
+			args = append(args, field, value)
+		}
+		if _, err := client.command(ctx, args...); err != nil {
+			return err
+		}
+	}
+	if payload.TTL > 0 {
+		if _, err := client.command(ctx, "EXPIRE", payload.Key, strconv.FormatInt(payload.TTL, 10)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func stringListFromRaw(raw json.RawMessage, label string) ([]string, error) {
+	var values []string
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, fmt.Errorf("%s value must be a JSON array of strings", label)
+	}
+	if len(values) == 0 {
+		return nil, fmt.Errorf("%s must contain at least one item", label)
+	}
+	return values, nil
+}
+
+func normalizeRedisType(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case "rejson-rl", "json":
+		return "json"
+	default:
+		return normalized
+	}
+}
+
+func scanRedisKeys(ctx context.Context, client *redisClient, pattern string, limit int) ([]string, error) {
+	cursor := "0"
+	keys := []string{}
+	for {
+		resp, err := client.command(ctx, "SCAN", cursor, "MATCH", pattern, "COUNT", "100")
+		if err != nil {
+			return nil, err
+		}
+		values, ok := resp.([]any)
+		if !ok || len(values) != 2 {
+			return nil, fmt.Errorf("unexpected redis scan response")
+		}
+		cursor, _ = values[0].(string)
+		for _, raw := range anySliceToStrings(values[1]) {
+			keys = append(keys, raw)
+			if len(keys) >= limit {
+				return keys, nil
+			}
+		}
+		if cursor == "0" {
+			return keys, nil
+		}
+	}
+}
+
+func redisScriptForValue(value redisValueResponse) []string {
+	lines := []string{"DEL " + redisQuote(value.Key)}
+	switch normalizeRedisType(value.Type) {
+	case "string":
+		lines = append(lines, "SET "+redisQuote(value.Key)+" "+redisQuote(fmt.Sprint(value.Value)))
+	case "hash":
+		if values, ok := value.Value.(map[string]string); ok {
+			args := []string{"HSET", redisQuote(value.Key)}
+			for field, item := range values {
+				args = append(args, redisQuote(field), redisQuote(item))
+			}
+			lines = append(lines, strings.Join(args, " "))
+		}
+	case "list":
+		if values, ok := value.Value.([]string); ok && len(values) > 0 {
+			args := []string{"RPUSH", redisQuote(value.Key)}
+			for _, item := range values {
+				args = append(args, redisQuote(item))
+			}
+			lines = append(lines, strings.Join(args, " "))
+		}
+	case "set":
+		if values, ok := value.Value.([]string); ok && len(values) > 0 {
+			args := []string{"SADD", redisQuote(value.Key)}
+			for _, item := range values {
+				args = append(args, redisQuote(item))
+			}
+			lines = append(lines, strings.Join(args, " "))
+		}
+	case "zset":
+		if values, ok := value.Value.([]map[string]string); ok && len(values) > 0 {
+			args := []string{"ZADD", redisQuote(value.Key)}
+			for _, item := range values {
+				args = append(args, redisQuote(item["score"]), redisQuote(item["member"]))
+			}
+			lines = append(lines, strings.Join(args, " "))
+		}
+	case "stream":
+		if values, ok := value.Value.([]map[string]any); ok {
+			for _, entry := range values {
+				fields, _ := entry["fields"].(map[string]string)
+				if len(fields) == 0 {
+					continue
+				}
+				args := []string{"XADD", redisQuote(value.Key), "*"}
+				for field, item := range fields {
+					args = append(args, redisQuote(field), redisQuote(item))
+				}
+				lines = append(lines, strings.Join(args, " "))
+			}
+		}
+	case "json":
+		body, _ := json.Marshal(value.Value)
+		lines = append(lines, "JSON.SET "+redisQuote(value.Key)+" $ "+redisQuote(string(body)))
+	}
+	if value.TTL > 0 {
+		lines = append(lines, "EXPIRE "+redisQuote(value.Key)+" "+strconv.FormatInt(value.TTL, 10))
+	}
+	return lines
+}
+
+func redisQuote(value string) string {
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return `"` + escaped + `"`
+}
+
+func parseRedisCommand(command string) ([]string, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil, fmt.Errorf("command is required")
+	}
+	var args []string
+	var current strings.Builder
+	var quote rune
+	escaped := false
+	for _, r := range command {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			} else {
+				current.WriteRune(r)
+			}
+			continue
+		}
+		if r == '\'' || r == '"' {
+			quote = r
+			continue
+		}
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' {
+			if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+			continue
+		}
+		current.WriteRune(r)
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quote")
+	}
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+	if len(args) == 0 {
+		return nil, fmt.Errorf("command is required")
+	}
+	return args, nil
+}
+
+type parsedRedisScriptCommand struct {
+	line int
+	text string
+}
+
+func parseRedisScript(script string, maxCommands int) ([]parsedRedisScriptCommand, error) {
+	var commands []parsedRedisScriptCommand
+	for idx, line := range strings.Split(script, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "--") {
+			continue
+		}
+		commands = append(commands, parsedRedisScriptCommand{line: idx + 1, text: trimmed})
+		if len(commands) > maxCommands {
+			return nil, fmt.Errorf("script is limited to %d commands", maxCommands)
+		}
+	}
+	if len(commands) == 0 {
+		return nil, fmt.Errorf("script is empty")
+	}
+	return commands, nil
+}
+
+func validateRedisCommand(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("command is required")
+	}
+	blocked := map[string]bool{
+		"ACL":       true,
+		"CONFIG":    true,
+		"DEBUG":     true,
+		"EVAL":      true,
+		"EVALSHA":   true,
+		"FLUSHALL":  true,
+		"FLUSHDB":   true,
+		"FUNCTION":  true,
+		"MIGRATE":   true,
+		"MODULE":    true,
+		"REPLICAOF": true,
+		"SCRIPT":    true,
+		"SHUTDOWN":  true,
+		"SLAVEOF":   true,
+	}
+	name := strings.ToUpper(args[0])
+	if blocked[name] {
+		return fmt.Errorf("redis command %s is blocked in the web console", name)
+	}
+	return nil
+}
+
+func openRedisClient(connID int64, dbOverride *int) (*redisClient, string, error) {
+	var in ConnectionInput
+	var ssl int
+	var encPassword string
+	var connName string
+	err := appdb.DB.QueryRow(
+		appdb.ConvertQuery(`SELECT name, driver, COALESCE(host,''), COALESCE(port,0), database, COALESCE(username,''), COALESCE(password,''), ssl FROM connections WHERE id=?`), connID,
+	).Scan(&connName, &in.Driver, &in.Host, &in.Port, &in.Database, &in.Username, &encPassword, &ssl)
+	if err != nil {
+		return nil, "", fmt.Errorf("connection not found")
+	}
+	if in.Driver != "redis" {
+		return nil, "", fmt.Errorf("connection is not redis")
+	}
+	password, err := decryptCredential(encPassword)
+	if err != nil {
+		return nil, "", fmt.Errorf("decryption error")
+	}
+	in.Password = password
+	in.SSL = ssl == 1
+	client, err := newRedisClientFromInput(in)
+	if err == nil && dbOverride != nil {
+		if *dbOverride < 0 {
+			return nil, "", fmt.Errorf("redis database must be a non-negative number")
+		}
+		client.db = *dbOverride
+	}
+	return client, connName, err
+}
+
+func redisDBFromRequest(r *http.Request) *int {
+	raw := strings.TrimSpace(r.URL.Query().Get("db"))
+	if raw == "" {
+		return nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 0 {
+		return nil
+	}
+	return &value
+}
+
+func newRedisClientFromInput(in ConnectionInput) (*redisClient, error) {
+	if strings.TrimSpace(in.Host) == "" {
+		return nil, fmt.Errorf("host is required")
+	}
+	if in.Port == 0 {
+		in.Port = 6379
+	}
+	db := 0
+	if strings.TrimSpace(in.Database) != "" {
+		parsed, err := strconv.Atoi(strings.TrimSpace(in.Database))
+		if err != nil || parsed < 0 {
+			return nil, fmt.Errorf("redis database must be a non-negative number")
+		}
+		db = parsed
+	}
+	return &redisClient{
+		address:  fmt.Sprintf("%s:%d", in.Host, in.Port),
+		username: in.Username,
+		password: in.Password,
+		db:       db,
+		tls:      in.SSL,
+		timeout:  3 * time.Second,
+	}, nil
+}
+
+func (c *redisClient) command(ctx context.Context, args ...string) (any, error) {
+	conn, err := c.dial(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	if c.password != "" {
+		authArgs := []string{"AUTH", c.password}
+		if c.username != "" {
+			authArgs = []string{"AUTH", c.username, c.password}
+		}
+		if err := writeRedisCommand(conn, authArgs...); err != nil {
+			return nil, err
+		}
+		if _, err := readRedisRESP(reader); err != nil {
+			return nil, err
+		}
+	}
+	if c.db > 0 {
+		if err := writeRedisCommand(conn, "SELECT", strconv.Itoa(c.db)); err != nil {
+			return nil, err
+		}
+		if _, err := readRedisRESP(reader); err != nil {
+			return nil, err
+		}
+	}
+	if err := writeRedisCommand(conn, args...); err != nil {
+		return nil, err
+	}
+	return readRedisRESP(reader)
+}
+
+func (c *redisClient) dial(ctx context.Context) (net.Conn, error) {
+	deadline := time.Now().Add(c.timeout)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	var conn net.Conn
+	var err error
+	dialer := &net.Dialer{Timeout: time.Until(deadline)}
+	if c.tls {
+		conn, err = tls.DialWithDialer(dialer, "tcp", c.address, &tls.Config{MinVersion: tls.VersionTLS12})
+	} else {
+		conn, err = dialer.DialContext(ctx, "tcp", c.address)
+	}
+	if err != nil {
+		return nil, err
+	}
+	_ = conn.SetDeadline(time.Now().Add(c.timeout))
+	return conn, nil
+}
+
+func writeRedisCommand(w io.Writer, args ...string) error {
+	if _, err := fmt.Fprintf(w, "*%d\r\n", len(args)); err != nil {
+		return err
+	}
+	for _, arg := range args {
+		if _, err := fmt.Fprintf(w, "$%d\r\n%s\r\n", len(arg), arg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readRedisRESP(r *bufio.Reader) (any, error) {
+	prefix, err := r.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+	switch prefix {
+	case '+':
+		return readRedisLine(r)
+	case '-':
+		line, lineErr := readRedisLine(r)
+		if lineErr != nil {
+			return nil, lineErr
+		}
+		return nil, errors.New(line)
+	case ':':
+		line, lineErr := readRedisLine(r)
+		if lineErr != nil {
+			return nil, lineErr
+		}
+		return strconv.ParseInt(line, 10, 64)
+	case '$':
+		line, lineErr := readRedisLine(r)
+		if lineErr != nil {
+			return nil, lineErr
+		}
+		size, parseErr := strconv.Atoi(line)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		if size == -1 {
+			return nil, nil
+		}
+		buf := make([]byte, size+2)
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, err
+		}
+		return string(buf[:size]), nil
+	case '*':
+		line, lineErr := readRedisLine(r)
+		if lineErr != nil {
+			return nil, lineErr
+		}
+		size, parseErr := strconv.Atoi(line)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		if size == -1 {
+			return nil, nil
+		}
+		values := make([]any, 0, size)
+		for i := 0; i < size; i++ {
+			value, itemErr := readRedisRESP(r)
+			if itemErr != nil {
+				return nil, itemErr
+			}
+			values = append(values, value)
+		}
+		return values, nil
+	default:
+		return nil, fmt.Errorf("unsupported RESP prefix %q", prefix)
+	}
+}
+
+func readRedisLine(r *bufio.Reader) (string, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r"), nil
+}
+
+func connectionIDFromPath(path string) (int64, error) {
+	trimmed := strings.TrimPrefix(path, "/api/connections/")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) == 0 {
+		return 0, fmt.Errorf("missing connection id")
+	}
+	return strconv.ParseInt(parts[0], 10, 64)
+}
+
+func queryInt(r *http.Request, key string, fallback, minValue, maxValue int) int {
+	raw := r.URL.Query().Get(key)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil {
+		return fallback
+	}
+	if value < minValue {
+		return minValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}
+
+func redisInt(value any, err error) (int64, bool) {
+	if err != nil {
+		return 0, false
+	}
+	n, ok := value.(int64)
+	return n, ok
+}
+
+func stringPairsToMap(value any) map[string]string {
+	items := anySliceToStrings(value)
+	result := make(map[string]string, len(items)/2)
+	for i := 0; i+1 < len(items); i += 2 {
+		result[items[i]] = items[i+1]
+	}
+	return result
+}
+
+func anySliceToStrings(value any) []string {
+	raw, ok := value.([]any)
+	if !ok {
+		return []string{}
+	}
+	items := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if s, ok := item.(string); ok {
+			items = append(items, s)
+		}
+	}
+	return items
+}
+
+func scanValues(value any) []string {
+	raw, ok := value.([]any)
+	if !ok || len(raw) != 2 {
+		return []string{}
+	}
+	return anySliceToStrings(raw[1])
+}
+
+func zsetPairs(value any) []map[string]string {
+	items := anySliceToStrings(value)
+	result := make([]map[string]string, 0, len(items)/2)
+	for i := 0; i+1 < len(items); i += 2 {
+		result = append(result, map[string]string{"member": items[i], "score": items[i+1]})
+	}
+	return result
+}
+
+func streamEntries(value any) []map[string]any {
+	raw, ok := value.([]any)
+	if !ok {
+		return []map[string]any{}
+	}
+	entries := make([]map[string]any, 0, len(raw))
+	for _, item := range raw {
+		entry, ok := item.([]any)
+		if !ok || len(entry) != 2 {
+			continue
+		}
+		id, _ := entry[0].(string)
+		entries = append(entries, map[string]any{
+			"id":     id,
+			"fields": stringPairsToMap(entry[1]),
+		})
+	}
+	return entries
+}
+
+func writeRedisAudit(r *http.Request, action string, connID int64, connName, target, errMsg string) {
+	username := strings.TrimSpace(r.Header.Get("X-Username"))
+	if username == "" {
+		username = "anonymous"
+	}
+	writeAuditEvent("redis", action, target, "", username, &connID, connName, "", 0, 0, errMsg)
+}

--- a/server/main.go
+++ b/server/main.go
@@ -294,6 +294,26 @@ func registerRoutes(mux *http.ServeMux, cfg *config.Config) {
 				handlers.ProfileColumn()(w, r)
 			case sub == "ping" && r.Method == http.MethodGet:
 				handlers.PingConnection()(w, r)
+			case sub == "redis" && len(parts) >= 3 && parts[2] == "ping" && r.Method == http.MethodGet:
+				requireAny(handlers.PermConnectionsView, handlers.PermSchemaBrowse)(handlers.RedisPing())(w, r)
+			case sub == "redis" && len(parts) >= 3 && parts[2] == "keys" && r.Method == http.MethodGet:
+				requireAny(handlers.PermSchemaBrowse, handlers.PermConnectionsView)(handlers.RedisKeys())(w, r)
+			case sub == "redis" && len(parts) >= 3 && parts[2] == "key" && r.Method == http.MethodGet:
+				requireAny(handlers.PermSchemaBrowse, handlers.PermConnectionsView)(handlers.RedisKeyValue())(w, r)
+			case sub == "redis" && len(parts) >= 3 && parts[2] == "key" && (r.Method == http.MethodPost || r.Method == http.MethodPut):
+				requireAny(handlers.PermConnectionsEdit, handlers.PermSchemaBrowse)(handlers.RedisWriteKey())(w, r)
+			case sub == "redis" && len(parts) >= 3 && parts[2] == "key" && r.Method == http.MethodDelete:
+				requireAny(handlers.PermConnectionsEdit, handlers.PermSchemaBrowse)(handlers.RedisDeleteKey())(w, r)
+			case sub == "redis" && len(parts) >= 3 && parts[2] == "rename" && r.Method == http.MethodPost:
+				requireAny(handlers.PermConnectionsEdit, handlers.PermSchemaBrowse)(handlers.RedisRenameKey())(w, r)
+			case sub == "redis" && len(parts) >= 3 && parts[2] == "move" && r.Method == http.MethodPost:
+				requireAny(handlers.PermConnectionsEdit, handlers.PermSchemaBrowse)(handlers.RedisMoveKey())(w, r)
+			case sub == "redis" && len(parts) >= 3 && parts[2] == "command" && r.Method == http.MethodPost:
+				requireAny(handlers.PermConnectionsEdit, handlers.PermSchemaBrowse)(handlers.RedisCommand())(w, r)
+			case sub == "redis" && len(parts) >= 3 && parts[2] == "script" && r.Method == http.MethodGet:
+				requireAny(handlers.PermConnectionsView, handlers.PermSchemaBrowse)(handlers.RedisGenerateScript())(w, r)
+			case sub == "redis" && len(parts) >= 3 && parts[2] == "script" && r.Method == http.MethodPost:
+				requireAny(handlers.PermConnectionsEdit, handlers.PermSchemaBrowse)(handlers.RedisExecuteScript())(w, r)
 			case sub == "backup" && r.Method == http.MethodGet:
 				requireAny(handlers.PermBackupsManage)(handlers.GetBackup())(w, r)
 			case sub == "restore" && r.Method == http.MethodPost:

--- a/web/src/components/layout/AppSidebar.vue
+++ b/web/src/components/layout/AppSidebar.vue
@@ -64,13 +64,14 @@ function toggleFolder(id: number) {
   else collapsedFolders.value.add(id)
 }
 
-const driverLabel: Record<string, string> = { postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS' }
+const driverLabel: Record<string, string> = { postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD' }
 
 function selectConn(conn: Connection) {
   emit('select-conn', conn.id)
-  const stayViews = ['schema', 'data', 'er', 'dashboard', 'query']
+  const stayViews = ['schema', 'data', 'er', 'dashboard', 'query', 'redis']
   const current = router.currentRoute.value.name as string
-  if (!stayViews.includes(current)) router.push({ name: 'query' })
+  if (conn.driver === 'redis' && current !== 'redis') router.push({ name: 'redis' })
+  else if (conn.driver !== 'redis' && (current === 'redis' || !stayViews.includes(current))) router.push({ name: 'query' })
 }
 
 async function deleteConn(conn: Connection) {

--- a/web/src/components/layout/ConnectionsDropdown.vue
+++ b/web/src/components/layout/ConnectionsDropdown.vue
@@ -38,8 +38,8 @@ const editFolderVisibility = ref<'private' | 'shared'>('private')
 const contextMenu = ref<{ x: number; y: number; type: 'folder' | 'conn'; item: ConnectionFolder | Connection } | null>(null)
 
 const FOLDER_COLORS = ['#4f9cf9','#56c490','#f97f4f','#c45ef9','#f9d44f','#f9584f','#4fc8f9','#9cf94f','#f94f9c']
-const driverLabel: Record<string, string> = { postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS' }
-const driverColor: Record<string, string> = { postgres: '#336791', mysql: '#f29111', mariadb: '#c0392b', mssql: '#cc2927' }
+const driverLabel: Record<string, string> = { postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD' }
+const driverColor: Record<string, string> = { postgres: '#336791', mysql: '#f29111', mariadb: '#c0392b', mssql: '#cc2927', redis: '#c6302b' }
 
 onMounted(async () => {
   await fetchFolders()
@@ -80,9 +80,10 @@ function toggleFolder(id: number) {
 function selectConn(conn: Connection) {
   emit('select-conn', conn.id)
   emit('close')
-  const stayViews = ['data', 'er', 'dashboard']
+  const stayViews = ['data', 'er', 'dashboard', 'redis']
   const current = router.currentRoute.value.name as string
-  if (!stayViews.includes(current)) router.push({ name: 'data' })
+  if (conn.driver === 'redis' && current !== 'redis') router.push({ name: 'redis' })
+  else if (conn.driver !== 'redis' && (current === 'redis' || !stayViews.includes(current))) router.push({ name: 'data' })
 }
 
 // ── Folder ops ──

--- a/web/src/components/layout/StatusBar.vue
+++ b/web/src/components/layout/StatusBar.vue
@@ -18,6 +18,7 @@ const driverLabel: Record<string, string> = {
   mysql: 'MySQL',
   mariadb: 'MariaDB',
   mssql: 'SQL Server',
+  redis: 'Redis',
 }
 </script>
 
@@ -26,8 +27,8 @@ const driverLabel: Record<string, string> = {
     <!-- Connection status -->
     <div
       class="statusbar__item statusbar__item--clickable"
-      @click="router.push({ name: activeConn ? 'query' : 'connections' })"
-      :title="activeConn ? `Open query editor for ${activeConn.name}` : 'Add a connection'"
+      @click="router.push({ name: activeConn?.driver === 'redis' ? 'redis' : activeConn ? 'query' : 'connections' })"
+      :title="activeConn ? `Open ${activeConn.driver === 'redis' ? 'Redis browser' : 'query editor'} for ${activeConn.name}` : 'Add a connection'"
     >
       <div class="statusbar__dot" :class="activeConn ? 'statusbar__dot--ok' : 'statusbar__dot--err'" />
       <span>{{ activeConn ? activeConn.name : 'No connection' }}</span>
@@ -47,7 +48,7 @@ const driverLabel: Record<string, string> = {
       <div class="statusbar__sep" />
       <div class="statusbar__item">
         <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="opacity:0.7"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg>
-        <span>{{ activeConn.database }}</span>
+        <span>{{ activeConn.driver === 'redis' ? `DB ${activeConn.database || 0}` : activeConn.database }}</span>
       </div>
     </template>
 

--- a/web/src/components/layout/TopNav.vue
+++ b/web/src/components/layout/TopNav.vue
@@ -23,8 +23,8 @@ const { connections } = useConnections()
 const activeConn = computed(() =>
   props.activeConnId != null ? connections.value.find(c => c.id === props.activeConnId) ?? null : null
 )
-const driverColor: Record<string, string> = { postgres: '#336791', mysql: '#f29111', mariadb: '#c0392b', mssql: '#cc2927' }
-const driverLabel: Record<string, string> = { postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS' }
+const driverColor: Record<string, string> = { postgres: '#336791', mysql: '#f29111', mariadb: '#c0392b', mssql: '#cc2927', redis: '#c6302b' }
+const driverLabel: Record<string, string> = { postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD' }
 
 // Nav group dropdown
 const openMenu = ref<string | null>(null)
@@ -54,15 +54,28 @@ const notificationPoll = ref<number | null>(null)
 const canViewNotifications = computed(() => hasAnyPermission(['notifications.view']))
 
 // ── Navigation structure ─────────────────────────────────────────
+type NavLink = {
+  name: string
+  label: string
+  icon: string
+  permissionsAny?: string[]
+}
+
+type MenuItem = NavLink & {
+  desc: string
+  section?: string
+}
+
+type MenuGroup = {
+  id: string
+  label: string
+  icon: string
+  items: MenuItem[]
+}
+
 // Direct links (no dropdown)
 const directLinks = computed(() => {
-  const links = [
-    {
-      name: 'analytics',
-      label: 'Analytics',
-      icon: 'dashboard',
-      permissionsAny: ['connections.view', 'savedqueries.manage', 'ai.use'],
-    },
+  const links: NavLink[] = [
     {
       name: 'docs',
       label: 'Docs',
@@ -74,23 +87,34 @@ const directLinks = computed(() => {
 })
 
 // Grouped dropdown menus (filtered by permissions)
-const allMenuGroups = [
+const allMenuGroups: MenuGroup[] = [
   {
-    id: 'build',
-    label: 'Build',
-    icon: 'table',
+    id: 'analytics',
+    label: 'Analytics',
+    icon: 'dashboard',
     items: [
-      { name: 'data',          label: 'SQL Studio',  desc: 'Browse tables, inspect schema, and run SQL in the main workbench', icon: 'table', permissionsAny: ['connections.view', 'query.execute', 'schema.browse'] },
-      { name: 'saved-queries', label: 'Saved Queries', desc: 'Reusable SQL and dataset-style query library', icon: 'saved', permissionsAny: ['savedqueries.manage'] },
+      { name: 'analytics', label: 'Analytics Home', desc: 'Start analysis workflows and review available analytics surfaces', icon: 'dashboard', permissionsAny: ['connections.view', 'savedqueries.manage', 'ai.use'] },
       { name: 'dashboards', label: 'Dashboards', desc: 'Compose saved queries into chart blocks and shared analytics views', icon: 'dashboard', permissionsAny: ['savedqueries.manage'] },
-      { name: 'ai-analytics',  label: 'AI Analytics', desc: 'Ask business questions and generate safe read-only analytics queries', icon: 'spark', permissionsAny: ['ai.use'] },
-      { name: 'er',            label: 'ER Diagram',    desc: 'Visualize relationships between tables before building analysis', icon: 'er', permissionsAny: ['schema.browse'] },
+      { name: 'saved-queries', label: 'Saved Queries', desc: 'Reusable SQL and dataset-style query library', icon: 'saved', permissionsAny: ['savedqueries.manage'] },
+      { name: 'ai-analytics', label: 'AI Analytics', desc: 'Ask business questions and generate safe read-only analytics queries', icon: 'spark', permissionsAny: ['ai.use'] },
       { name: 'settings', label: 'AI Settings', desc: 'Manage your personal AI provider key, base URL, and model', icon: 'settings', permissionsAny: ['ai.use', 'ai.manage'] },
     ],
   },
   {
+    id: 'database',
+    label: 'Database',
+    icon: 'table',
+    items: [
+      { name: 'data', label: 'SQL Studio', desc: 'Browse tables, inspect schema, and run SQL in the main workbench', icon: 'table', section: 'RDBMS', permissionsAny: ['connections.view', 'query.execute', 'schema.browse'] },
+      { name: 'er', label: 'ER Diagram', desc: 'Visualize relationships between tables before building analysis', icon: 'er', section: 'RDBMS', permissionsAny: ['schema.browse'] },
+      { name: 'diff', label: 'Schema Diff', desc: 'Compare schema structure across environments', icon: 'diff', section: 'RDBMS', permissionsAny: ['schema.diff.view'] },
+      { name: 'row-history', label: 'Row History', desc: 'See row-level INSERT, UPDATE, DELETE changes', icon: 'rowhistory', section: 'RDBMS', permissionsAny: ['rowhistory.view'] },
+      { name: 'redis', label: 'Redis Browser', desc: 'Scan keys and inspect Redis values from managed connections', icon: 'table', section: 'Database Cache', permissionsAny: ['connections.view', 'schema.browse'] },
+    ],
+  },
+  {
     id: 'operate',
-    label: 'Operate',
+    label: 'Operations',
     icon: 'activity',
     items: [
       { name: 'dashboard', label: 'Operations Overview', desc: 'Connection footprint, size, and slow-query pressure across environments', icon: 'dashboard', permissionsAny: ['connections.view'] },
@@ -98,21 +122,19 @@ const allMenuGroups = [
       { name: 'database-audit', label: 'Database Audit', desc: 'Live sessions and external access signals', icon: 'shieldlog', permissionsAny: ['audit.view'] },
       { name: 'audit',       label: 'Audit Log',   desc: 'Track access, actions, and query events', icon: 'audit', permissionsAny: ['audit.view'] },
       { name: 'notifications', label: 'Notifications', desc: 'Inbox, integrations, routing rules, and delivery logs', icon: 'audit', permissionsAny: ['notifications.view'] },
-      { name: 'row-history', label: 'Row History', desc: 'See row-level INSERT, UPDATE, DELETE changes', icon: 'rowhistory', permissionsAny: ['rowhistory.view'] },
       { name: 'watcher',     label: 'Watchers',    desc: 'Monitor important table or query activity', icon: 'watcher', permissionsAny: ['query.execute'] },
       { name: 'health',      label: 'Health',      desc: 'Connection and service health status', icon: 'health', permissionsAny: ['health.view'] },
     ],
   },
   {
     id: 'govern',
-    label: 'Govern',
+    label: 'Governance',
     icon: 'wrench',
     items: [
       { name: 'approvals',   label: 'Approvals',   desc: 'Review and approve controlled SQL changes', icon: 'workflow', permissionsAny: ['query.execute', 'query.approve'] },
       { name: 'change-sets', label: 'Change Sets', desc: 'Plan, validate, and run database changes', icon: 'changeset', permissionsAny: ['query.execute', 'query.approve'] },
       { name: 'data-scripts', label: 'Data Scripts', desc: 'Preview programmable data updates before approval', icon: 'changeset', permissionsAny: ['query.execute', 'query.approve'] },
       { name: 'data-script-requests', label: 'Script Requests', desc: 'Global queue of data script plans and approvals', icon: 'workflow', permissionsAny: ['query.execute', 'query.approve'] },
-      { name: 'diff',        label: 'Schema Diff', desc: 'Compare schema structure across environments', icon: 'diff', permissionsAny: ['schema.diff.view'] },
       { name: 'backup',      label: 'Backup',      desc: 'Request database downloads or use direct backup and restore', icon: 'backup', permissionsAny: ['backups.manage', 'query.execute', 'query.approve'] },
       { name: 'scheduler',   label: 'Scheduler',   desc: 'Schedule recurring queries and jobs', icon: 'scheduler', permissionsAny: ['schedules.manage'] },
       { name: 'workflows',   label: 'Workflows',   desc: 'Configure approval workflows and routing', icon: 'workflow', permissionsAny: ['workflows.manage'] },
@@ -156,6 +178,20 @@ const menuGroups = computed(() => {
 // Is any item in a group active?
 function groupActive(group: { items: Array<{ name: string }> }) {
   return group.items.some(i => i.name === route.name)
+}
+
+function groupedDropdownSections(items: MenuItem[]) {
+  const sections: Array<{ label: string; items: MenuItem[] }> = []
+  for (const item of items) {
+    const label = item.section || ''
+    let section = sections.find(s => s.label === label)
+    if (!section) {
+      section = { label, items: [] }
+      sections.push(section)
+    }
+    section.items.push(item)
+  }
+  return sections
 }
 
 function toggleMenu(id: string) {
@@ -322,6 +358,7 @@ watch([() => authEnabled.value, canViewNotifications, () => user.value?.id], () 
         >
           <!-- Group icons -->
           <svg v-if="group.icon === 'table'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
+          <svg v-else-if="group.icon === 'dashboard'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="9" height="11" rx="1"/><rect x="13" y="2" width="9" height="7" rx="1"/><rect x="2" y="15" width="9" height="7" rx="1"/><rect x="13" y="11" width="9" height="11" rx="1"/></svg>
           <svg v-else-if="group.icon === 'settings'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
           <svg v-else-if="group.icon === 'wrench'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
           <svg v-else-if="group.icon === 'activity'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
@@ -339,15 +376,17 @@ watch([() => authEnabled.value, canViewNotifications, () => user.value?.id], () 
         <!-- Dropdown panel -->
         <div v-if="openMenu === group.id" class="topnav__dropdown">
           <div class="topnav__dropdown-label">{{ group.label }}</div>
-          <button
-            v-for="item in group.items"
-            :key="item.name"
-            class="topnav__dropdown-item"
-            :class="{ 'topnav__dropdown-item--active': route.name === item.name }"
-            @click="navigate(item.name)"
-            type="button"
-          >
-            <div class="topnav__dropdown-icon">
+          <template v-for="section in groupedDropdownSections(group.items)" :key="section.label || 'default'">
+            <div v-if="section.label" class="topnav__dropdown-section">{{ section.label }}</div>
+            <button
+              v-for="item in section.items"
+              :key="item.name"
+              class="topnav__dropdown-item"
+              :class="{ 'topnav__dropdown-item--active': route.name === item.name }"
+              @click="navigate(item.name)"
+              type="button"
+            >
+              <div class="topnav__dropdown-icon">
               <svg v-if="item.icon === 'dashboard'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="9" height="11" rx="1"/><rect x="13" y="2" width="9" height="7" rx="1"/><rect x="2" y="15" width="9" height="7" rx="1"/><rect x="13" y="11" width="9" height="11" rx="1"/></svg>
               <svg v-else-if="item.icon === 'layers'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"/><polyline points="2 17 12 22 22 17"/><polyline points="2 12 12 17 22 12"/></svg>
               <svg v-else-if="item.icon === 'table'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
@@ -369,15 +408,16 @@ watch([() => authEnabled.value, canViewNotifications, () => user.value?.id], () 
               <svg v-else-if="item.icon === 'shieldlog'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v6c0 5-3.5 8-7 9-3.5-1-7-4-7-9V6l7-3z"/><path d="M9 12h6"/><path d="M12 9v6"/></svg>
               <svg v-else-if="item.icon === 'health'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
               <svg v-else-if="item.icon === 'rowhistory'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v4H3z"/><path d="M3 10h18v4H3z"/><path d="M3 17h18v4H3z"/></svg>
-            </div>
-            <div class="topnav__dropdown-info">
-              <span class="topnav__dropdown-name">{{ item.label }}</span>
-              <span class="topnav__dropdown-desc">{{ item.desc }}</span>
-            </div>
-            <svg v-if="route.name === item.name" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" style="color:var(--brand);flex-shrink:0">
-              <polyline points="20 6 9 17 4 12"/>
-            </svg>
-          </button>
+              </div>
+              <div class="topnav__dropdown-info">
+                <span class="topnav__dropdown-name">{{ item.label }}</span>
+                <span class="topnav__dropdown-desc">{{ item.desc }}</span>
+              </div>
+              <svg v-if="route.name === item.name" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" style="color:var(--brand);flex-shrink:0">
+                <polyline points="20 6 9 17 4 12"/>
+              </svg>
+            </button>
+          </template>
         </div>
       </div>
     </nav>
@@ -654,6 +694,15 @@ watch([() => authEnabled.value, canViewNotifications, () => user.value?.id], () 
   letter-spacing: 0.7px;
   color: var(--text-muted);
   padding: 6px 10px 4px;
+}
+
+.topnav__dropdown-section {
+  padding: 8px 10px 4px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
 }
 
 .topnav__dropdown-item {

--- a/web/src/composables/useConnections.ts
+++ b/web/src/composables/useConnections.ts
@@ -1,7 +1,7 @@
 import { ref } from 'vue'
 import axios from 'axios'
 
-export type DbDriver = 'postgres' | 'mysql' | 'mariadb' | 'mssql'
+export type DbDriver = 'postgres' | 'mysql' | 'mariadb' | 'mssql' | 'redis'
 
 export interface Connection {
   id: number

--- a/web/src/composables/useRedis.ts
+++ b/web/src/composables/useRedis.ts
@@ -1,0 +1,107 @@
+import axios from 'axios'
+
+export interface RedisKeySummary {
+  key: string
+  type: string
+  ttl: number
+}
+
+export interface RedisKeysResponse {
+  cursor: string
+  keys: RedisKeySummary[]
+}
+
+export interface RedisValueResponse {
+  key: string
+  type: string
+  ttl: number
+  length?: number
+  value: unknown
+  truncated: boolean
+}
+
+export type RedisWritableType = 'string' | 'hash' | 'list' | 'set' | 'zset' | 'stream' | 'json'
+
+export interface RedisWritePayload {
+  key: string
+  type: RedisWritableType
+  value: unknown
+  ttl: number
+}
+
+export interface RedisScriptResult {
+  line: number
+  command: string
+  result?: unknown
+  error?: string
+}
+
+export interface RedisPingResponse {
+  status: string
+  message: string
+  latency_ms: number
+}
+
+export function useRedis() {
+  async function ping(connId: number, db?: number) {
+    const { data } = await axios.get<RedisPingResponse>(`/api/connections/${connId}/redis/ping`, {
+      params: { db },
+    })
+    return data
+  }
+
+  async function fetchKeys(connId: number, pattern = '*', cursor = '0', count = 100, db?: number) {
+    const { data } = await axios.get<RedisKeysResponse>(`/api/connections/${connId}/redis/keys`, {
+      params: { pattern, cursor, count, db },
+    })
+    return data
+  }
+
+  async function fetchValue(connId: number, key: string, db?: number) {
+    const { data } = await axios.get<RedisValueResponse>(`/api/connections/${connId}/redis/key`, {
+      params: { key, db },
+    })
+    return data
+  }
+
+  async function saveKey(connId: number, payload: RedisWritePayload, db?: number) {
+    await axios.put(`/api/connections/${connId}/redis/key`, { ...payload, db })
+  }
+
+  async function deleteKey(connId: number, key: string, db?: number) {
+    await axios.delete(`/api/connections/${connId}/redis/key`, { params: { key, db } })
+  }
+
+  async function renameKey(connId: number, oldKey: string, newKey: string, db?: number) {
+    await axios.post(`/api/connections/${connId}/redis/rename`, { old_key: oldKey, new_key: newKey, db })
+  }
+
+  async function moveKey(connId: number, key: string, fromDb: number, toDb: number, overwrite: boolean) {
+    await axios.post(`/api/connections/${connId}/redis/move`, {
+      key,
+      from_db: fromDb,
+      to_db: toDb,
+      overwrite,
+    })
+  }
+
+  async function runCommand(connId: number, command: string, db?: number) {
+    const { data } = await axios.post<{ result: unknown }>(`/api/connections/${connId}/redis/command`, { command, db })
+    return data.result
+  }
+
+  async function generateScript(connId: number, params: { key?: string; pattern?: string; db?: number }) {
+    const { data } = await axios.get<string>(`/api/connections/${connId}/redis/script`, {
+      params,
+      responseType: 'text',
+    })
+    return data
+  }
+
+  async function executeScript(connId: number, script: string, db?: number) {
+    const { data } = await axios.post<{ results: RedisScriptResult[] }>(`/api/connections/${connId}/redis/script`, { script, db })
+    return data.results
+  }
+
+  return { ping, fetchKeys, fetchValue, saveKey, deleteKey, renameKey, moveKey, runCommand, generateScript, executeScript }
+}

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -140,6 +140,12 @@ const router = createRouter({
           meta: { requiredPermissionsAny: ['connections.view', 'query.execute', 'schema.browse'] },
         },
         {
+          path: 'redis',
+          name: 'redis',
+          component: () => import('@/views/RedisView.vue'),
+          meta: { requiredPermissionsAny: ['connections.view', 'schema.browse'] },
+        },
+        {
           path: 'connections',
           name: 'connections',
           component: () => import('@/views/ConnectionsView.vue'),

--- a/web/src/styles/main.css
+++ b/web/src/styles/main.css
@@ -349,6 +349,7 @@ body {
 .conn-badge--mysql   { background: var(--mysql-bg);   color: var(--mysql); }
 .conn-badge--mariadb { background: #c0392b22;          color: #c0392b; }
 .conn-badge--mssql   { background: var(--mssql-bg);   color: var(--mssql); }
+.conn-badge--redis   { background: rgba(198, 48, 43, 0.14); color: #c6302b; }
 
 .conn-item__body { flex: 1; min-width: 0; }
 .conn-item__name {

--- a/web/src/views/ConnectionsView.vue
+++ b/web/src/views/ConnectionsView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, reactive, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import axios from 'axios'
 import { useConnections, type DbDriver, type ConnectionForm } from '@/composables/useConnections'
 import { useFolders } from '@/composables/useFolders'
@@ -10,6 +11,8 @@ const { connections, loading, testConnection, saveConnection, removeConnection, 
 const { folders, fetchFolders, moveConnection, setConnectionVisibility } = useFolders()
 const toast = useToast()
 const { confirm } = useConfirm()
+const router = useRouter()
+const emit = defineEmits<{ (e: 'set-conn', id: number): void }>()
 
 onMounted(() => fetchFolders())
 
@@ -24,6 +27,7 @@ const defaultPorts: Record<DbDriver, number> = {
   mysql: 3306,
   mariadb: 3306,
   mssql: 1433,
+  redis: 6379,
 }
 
 const form = reactive<ConnectionForm>({
@@ -45,11 +49,36 @@ const form = reactive<ConnectionForm>({
   visibility: 'shared',
 })
 
-const drivers: Array<{ key: DbDriver; label: string; badge: string; sub: string }> = [
-  { key: 'postgres', label: 'PostgreSQL', badge: 'PG',  sub: 'v12+' },
-  { key: 'mysql',    label: 'MySQL',      badge: 'MY',  sub: 'v8+' },
-  { key: 'mariadb',  label: 'MariaDB',    badge: 'MB',  sub: 'v10+' },
-  { key: 'mssql',    label: 'SQL Server', badge: 'MS',  sub: '2019+' },
+type DriverOption = { key: DbDriver; label: string; badge: string; sub: string }
+
+const driverGroups: Array<{ key: string; label: string; options: DriverOption[] }> = [
+  {
+    key: 'rdbms',
+    label: 'RDBMS',
+    options: [
+      { key: 'postgres', label: 'PostgreSQL', badge: 'PG',  sub: 'v12+' },
+      { key: 'mysql',    label: 'MySQL',      badge: 'MY',  sub: 'v8+' },
+      { key: 'mariadb',  label: 'MariaDB',    badge: 'MB',  sub: 'v10+' },
+      { key: 'mssql',    label: 'SQL Server', badge: 'MS',  sub: '2019+' },
+    ],
+  },
+  {
+    key: 'nosql',
+    label: 'NoSQL',
+    options: [],
+  },
+  {
+    key: 'cache',
+    label: 'Database Cache',
+    options: [
+      { key: 'redis', label: 'Redis', badge: 'RD', sub: 'v6+' },
+    ],
+  },
+  {
+    key: 'other',
+    label: 'Other',
+    options: [],
+  },
 ]
 
 function selectDriver(d: DbDriver) {
@@ -162,6 +191,7 @@ function parseConnectionURL(raw: string) {
       postgres: 'postgres', postgresql: 'postgres',
       mysql: 'mysql', mariadb: 'mariadb',
       mssql: 'mssql', sqlserver: 'mssql',
+      redis: 'redis', rediss: 'redis',
     }
     const driver = driverMap[scheme] ?? ('postgres' as DbDriver)
     form.driver = driver
@@ -170,7 +200,7 @@ function parseConnectionURL(raw: string) {
     form.database = url.pathname.replace(/^\//, '')
     form.username = decodeURIComponent(url.username || '')
     form.password = decodeURIComponent(url.password || '')
-    form.ssl = url.searchParams.get('sslmode') === 'require' || url.searchParams.get('ssl') === 'true'
+    form.ssl = scheme === 'rediss' || url.searchParams.get('sslmode') === 'require' || url.searchParams.get('ssl') === 'true'
     if (!form.name) form.name = `${driver} / ${form.database}`
     showURLImport.value = false
     urlInput.value = ''
@@ -178,6 +208,15 @@ function parseConnectionURL(raw: string) {
   } catch {
     // ignore parse errors - let user fix the URL
   }
+}
+
+function driverBadge(driver: DbDriver) {
+  return ({ postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD' } as Record<DbDriver, string>)[driver]
+}
+
+function openConnection(id: number, driver: DbDriver) {
+  emit('set-conn', id)
+  router.push({ name: driver === 'redis' ? 'redis' : 'data' })
 }
 
 async function handleDelete(id: number, name: string) {
@@ -233,7 +272,7 @@ async function handleDelete(id: number, name: string) {
             class="conn-row"
           >
             <div class="conn-badge" :class="`conn-badge--${conn.driver}`" style="width:36px;height:36px;border-radius:var(--r-sm);font-size:12px">
-              {{ conn.driver === 'postgres' ? 'PG' : conn.driver === 'mysql' ? 'MY' : conn.driver === 'mariadb' ? 'MB' : 'MS' }}
+              {{ driverBadge(conn.driver) }}
             </div>
             <div style="flex:1;min-width:0">
               <div style="font-size:13px;font-weight:600;color:var(--text-primary);display:flex;align-items:center;gap:6px">
@@ -242,13 +281,16 @@ async function handleDelete(id: number, name: string) {
                 <span v-else style="font-size:11px" title="Shared">🌐</span>
               </div>
               <div style="font-size:11.5px;font-family:var(--mono);color:var(--text-muted);margin-top:2px">
-                {{ conn.username ? `${conn.username}@` : '' }}{{ conn.host }}:{{ conn.port }}/{{ conn.database }}
+                {{ conn.username ? `${conn.username}@` : '' }}{{ conn.host }}:{{ conn.port }}/{{ conn.driver === 'redis' ? `db${conn.database || 0}` : conn.database }}
               </div>
               <div v-if="conn.folder_id" style="font-size:10.5px;color:var(--text-muted);margin-top:2px">
                 📁 {{ folders.find(f => f.id === conn.folder_id)?.name ?? 'Folder' }}
               </div>
             </div>
             <span class="badge badge--default">{{ conn.driver.toUpperCase() }}</span>
+            <button class="base-btn base-btn--ghost base-btn--sm" @click="openConnection(conn.id, conn.driver)">
+              Open
+            </button>
             <!-- Quick folder assign -->
             <select
               :value="conn.folder_id ?? ''"
@@ -298,7 +340,7 @@ async function handleDelete(id: number, name: string) {
                 <input
                   v-model="urlInput"
                   class="base-input"
-                  placeholder="postgres://user:pass@host:5432/dbname"
+                  placeholder="postgres://user:pass@host:5432/dbname or redis://user:pass@host:6379/0"
                   style="flex:1;font-family:var(--font-mono);font-size:11px"
                   @keydown.enter="parseConnectionURL(urlInput)"
                 />
@@ -309,21 +351,30 @@ async function handleDelete(id: number, name: string) {
             <!-- Driver selection -->
             <div class="form-group">
               <label class="form-label">Database Engine</label>
-              <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:6px">
-                <button
-                  v-for="d in drivers"
-                  :key="d.key"
-                  class="provider-card"
-                  :class="[`provider-card--${d.key}`, { 'is-active': form.driver === d.key }]"
-                  @click="selectDriver(d.key)"
-                >
-                  <div class="provider-card__icon" :class="`provider-card__icon--${d.key}`">{{ d.badge }}</div>
-                  <div class="provider-card__body">
-                    <span class="provider-card__name">{{ d.label }}</span>
-                    <span class="provider-card__sub">{{ d.sub }}</span>
+              <div class="provider-groups">
+                <div v-for="group in driverGroups" :key="group.key" class="provider-group">
+                  <div class="provider-group__head">
+                    <span>{{ group.label }}</span>
+                    <span>{{ group.options.length }}</span>
                   </div>
-                  <svg v-if="form.driver === d.key" class="provider-card__check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
-                </button>
+                  <div v-if="group.options.length" class="provider-grid">
+                    <button
+                      v-for="d in group.options"
+                      :key="d.key"
+                      class="provider-card"
+                      :class="[`provider-card--${d.key}`, { 'is-active': form.driver === d.key }]"
+                      @click="selectDriver(d.key)"
+                    >
+                      <div class="provider-card__icon" :class="`provider-card__icon--${d.key}`">{{ d.badge }}</div>
+                      <div class="provider-card__body">
+                        <span class="provider-card__name">{{ d.label }}</span>
+                        <span class="provider-card__sub">{{ d.sub }}</span>
+                      </div>
+                      <svg v-if="form.driver === d.key" class="provider-card__check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                    </button>
+                  </div>
+                  <div v-else class="provider-group__empty">No drivers yet</div>
+                </div>
               </div>
             </div>
 
@@ -345,14 +396,14 @@ async function handleDelete(id: number, name: string) {
               </div>
 
               <div class="form-group">
-                <label class="form-label">Database</label>
-                <input v-model="form.database" class="base-input" placeholder="mydb" />
+              <label class="form-label">{{ form.driver === 'redis' ? 'Database Index' : 'Database' }}</label>
+                <input v-model="form.database" class="base-input" :placeholder="form.driver === 'redis' ? '0' : 'mydb'" />
               </div>
 
               <div class="form-row">
                 <div class="form-group">
                   <label class="form-label">Username</label>
-                  <input v-model="form.username" class="base-input" placeholder="postgres" />
+                  <input v-model="form.username" class="base-input" :placeholder="form.driver === 'redis' ? 'default' : 'postgres'" />
                 </div>
                 <div class="form-group">
                   <label class="form-label">Password</label>
@@ -526,6 +577,43 @@ async function handleDelete(id: number, name: string) {
 }
 
 /* ── Provider cards ── */
+.provider-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.provider-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.provider-group__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.provider-group__empty {
+  padding: 8px 10px;
+  border: 1px dashed var(--border);
+  border-radius: var(--r-sm);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.provider-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
 .provider-card {
   display: flex;
   align-items: center;
@@ -564,6 +652,7 @@ async function handleDelete(id: number, name: string) {
 .provider-card__icon--mysql    { background: #e48e00; }
 .provider-card__icon--mariadb  { background: #c0765a; }
 .provider-card__icon--mssql    { background: #cc2927; }
+.provider-card__icon--redis    { background: #c6302b; }
 
 .provider-card__body {
   display: flex;

--- a/web/src/views/RedisView.vue
+++ b/web/src/views/RedisView.vue
@@ -1,0 +1,1416 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
+import { useConnections } from '@/composables/useConnections'
+import { useRedis, type RedisKeySummary, type RedisScriptResult, type RedisValueResponse, type RedisWritableType } from '@/composables/useRedis'
+import { useToast } from '@/composables/useToast'
+import { useConfirm } from '@/composables/useConfirm'
+
+const props = defineProps<{ activeConnId: number | null }>()
+const emit = defineEmits<{ (e: 'set-conn', id: number): void }>()
+
+const { connections, fetchConnections } = useConnections()
+const { ping, fetchKeys, fetchValue, saveKey, deleteKey, renameKey, moveKey, runCommand, generateScript, executeScript } = useRedis()
+const toast = useToast()
+const { confirm } = useConfirm()
+
+const pattern = ref('*')
+const cursor = ref('0')
+const selectedDb = ref(0)
+const keys = ref<RedisKeySummary[]>([])
+const selectedKey = ref('')
+const value = ref<RedisValueResponse | null>(null)
+const loadingKeys = ref(false)
+const loadingValue = ref(false)
+const redisConnected = ref(true)
+const reconnecting = ref(false)
+const connectionError = ref('')
+const lastPingMs = ref<number | null>(null)
+let keyLoadSeq = 0
+let valueLoadSeq = 0
+const activeWorkTab = ref<'value' | 'edit' | 'script' | 'console'>('value')
+const saving = ref(false)
+const editorOpen = ref(false)
+const editingExisting = ref(false)
+const treeMode = ref(true)
+const formKey = ref('')
+const formType = ref<RedisWritableType>('string')
+const formTTL = ref<number>(0)
+const formValue = ref('')
+const renameOpen = ref(false)
+const renameValue = ref('')
+const moveOpen = ref(false)
+const moveTargetDb = ref(1)
+const moveOverwrite = ref(false)
+const command = ref('')
+const commandResult = ref<unknown>(null)
+const runningCommand = ref(false)
+const scriptText = ref('')
+const generatingScript = ref(false)
+const runningScript = ref(false)
+const scriptResults = ref<RedisScriptResult[]>([])
+const editorPanel = ref<HTMLElement | null>(null)
+const renamePanel = ref<HTMLElement | null>(null)
+const movePanel = ref<HTMLElement | null>(null)
+const scriptPanel = ref<HTMLElement | null>(null)
+
+const redisTypes: Array<{ value: RedisWritableType; label: string }> = [
+  { value: 'string', label: 'String' },
+  { value: 'hash', label: 'Hash' },
+  { value: 'list', label: 'List' },
+  { value: 'set', label: 'Set' },
+  { value: 'zset', label: 'Sorted Set' },
+  { value: 'stream', label: 'Stream' },
+  { value: 'json', label: 'JSON' },
+]
+
+const redisDbIndexes = Array.from({ length: 16 }, (_, index) => index)
+
+const keyGroups = computed(() => {
+  const groups = new Map<string, RedisKeySummary[]>()
+  for (const item of keys.value) {
+    const idx = item.key.indexOf(':')
+    const group = idx > 0 ? item.key.slice(0, idx) : 'root'
+    if (!groups.has(group)) groups.set(group, [])
+    groups.get(group)!.push(item)
+  }
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, items]) => ({ name, items }))
+})
+
+const commandPreview = computed(() => {
+  const key = formKey.value.trim() || '<key>'
+  const ttl = Number(formTTL.value || 0)
+  const lines: string[] = [`DEL ${quoteCommandArg(key)}`]
+  switch (formType.value) {
+    case 'string':
+      lines.push(`SET ${quoteCommandArg(key)} ${quoteCommandArg(formValue.value)}`)
+      break
+    case 'hash':
+      lines.push(`HSET ${quoteCommandArg(key)} <field> <value> ...`)
+      break
+    case 'list':
+      lines.push(`RPUSH ${quoteCommandArg(key)} <item> ...`)
+      break
+    case 'set':
+      lines.push(`SADD ${quoteCommandArg(key)} <member> ...`)
+      break
+    case 'zset':
+      lines.push(`ZADD ${quoteCommandArg(key)} <score> <member> ...`)
+      break
+    case 'stream':
+      lines.push(`XADD ${quoteCommandArg(key)} * <field> <value> ...`)
+      break
+    case 'json':
+      lines.push(`JSON.SET ${quoteCommandArg(key)} $ <json>`)
+      break
+  }
+  if (ttl > 0) lines.push(`EXPIRE ${quoteCommandArg(key)} ${ttl}`)
+  return lines.join('\n')
+})
+
+const activeConn = computed(() =>
+  props.activeConnId != null ? connections.value.find((c) => c.id === props.activeConnId) ?? null : null,
+)
+const redisConnections = computed(() => connections.value.filter((c) => c.driver === 'redis'))
+const isRedis = computed(() => activeConn.value?.driver === 'redis')
+const redisUsable = computed(() => isRedis.value && redisConnected.value)
+const keyTypeCounts = computed(() => {
+  const counts = new Map<string, number>()
+  for (const item of keys.value) counts.set(item.type, (counts.get(item.type) || 0) + 1)
+  return Array.from(counts.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([type, count]) => ({ type, count }))
+})
+
+onMounted(async () => {
+  if (!connections.value.length) await fetchConnections()
+  if (!isRedis.value && redisConnections.value.length === 1) {
+    emit('set-conn', redisConnections.value[0].id)
+    return
+  }
+  if (isRedis.value) await reconnectRedis(false)
+})
+
+watch(() => props.activeConnId, async () => {
+  resetRedisWorkspace()
+  redisConnected.value = true
+  connectionError.value = ''
+  lastPingMs.value = null
+  selectedDb.value = Number(activeConn.value?.database || 0)
+  if (isRedis.value) await reconnectRedis(false)
+})
+
+watch(selectedDb, async () => {
+  resetRedisWorkspace()
+  editorOpen.value = false
+  renameOpen.value = false
+  moveOpen.value = false
+  scriptText.value = ''
+  if (redisUsable.value) await loadKeys(true)
+})
+
+async function loadKeys(reset = false) {
+  if (!activeConn.value || !redisUsable.value) return
+  const seq = ++keyLoadSeq
+  const db = selectedDb.value
+  loadingKeys.value = true
+  try {
+    const nextCursor = reset ? '0' : cursor.value
+    const data = await fetchKeys(activeConn.value.id, pattern.value || '*', nextCursor, 100, db)
+    if (seq !== keyLoadSeq || db !== selectedDb.value) return
+    cursor.value = data.cursor
+    keys.value = reset ? data.keys : [...keys.value, ...data.keys]
+  } catch {
+    if (seq === keyLoadSeq) {
+      connectionError.value = 'Failed to load Redis keys'
+      toast.error('Failed to load Redis keys')
+    }
+  } finally {
+    if (seq === keyLoadSeq) loadingKeys.value = false
+  }
+}
+
+async function openKey(key: string) {
+  if (!activeConn.value || !redisUsable.value) return
+  const seq = ++valueLoadSeq
+  const db = selectedDb.value
+  selectedKey.value = key
+  loadingValue.value = true
+  try {
+    const result = await fetchValue(activeConn.value.id, key, db)
+    if (seq !== valueLoadSeq || db !== selectedDb.value) return
+    value.value = result
+    activeWorkTab.value = 'value'
+  } catch {
+    if (seq === valueLoadSeq) {
+      connectionError.value = 'Failed to read Redis key'
+      toast.error('Failed to read Redis key')
+    }
+  } finally {
+    if (seq === valueLoadSeq) loadingValue.value = false
+  }
+}
+
+async function openCreateForm() {
+  if (!redisUsable.value) return
+  editingExisting.value = false
+  formKey.value = ''
+  formType.value = 'string'
+  formTTL.value = 0
+  formValue.value = ''
+  editorOpen.value = true
+  renameOpen.value = false
+  activeWorkTab.value = 'edit'
+}
+
+async function openEditForm() {
+  if (!value.value) return
+  editingExisting.value = true
+  formKey.value = value.value.key
+  formType.value = writableType(value.value.type)
+  formTTL.value = value.value.ttl > 0 ? value.value.ttl : 0
+  formValue.value = value.value.type === 'string'
+    ? String(value.value.value ?? '')
+    : JSON.stringify(value.value.value, null, 2)
+  editorOpen.value = true
+  renameOpen.value = false
+  activeWorkTab.value = 'edit'
+}
+
+async function saveRedisKey() {
+  if (!activeConn.value || !redisUsable.value) return
+  const key = formKey.value.trim()
+  if (!key) {
+    toast.error('Key is required')
+    return
+  }
+  let parsed: unknown
+  try {
+    parsed = parseEditorValue()
+  } catch (err) {
+    toast.error(err instanceof Error ? err.message : 'Invalid value')
+    return
+  }
+  saving.value = true
+  try {
+    await saveKey(activeConn.value.id, {
+      key,
+      type: formType.value,
+      value: parsed,
+      ttl: Number(formTTL.value || 0),
+    }, selectedDb.value)
+    toast.success('Redis key saved')
+    editorOpen.value = false
+    await loadKeys(true)
+    await openKey(key)
+  } catch {
+    toast.error('Failed to save Redis key')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function removeSelectedKey() {
+  if (!activeConn.value || !value.value || !redisUsable.value) return
+  const ok = await confirm(`Delete Redis key "${value.value.key}"? This cannot be undone.`, 'Delete Redis Key')
+  if (!ok) return
+  try {
+    await deleteKey(activeConn.value.id, value.value.key, selectedDb.value)
+    toast.success('Redis key deleted')
+    selectedKey.value = ''
+    value.value = null
+    await loadKeys(true)
+  } catch {
+    toast.error('Failed to delete Redis key')
+  }
+}
+
+async function openRenameForm() {
+  if (!value.value) return
+  renameValue.value = value.value.key
+  renameOpen.value = true
+  moveOpen.value = false
+  editorOpen.value = false
+  activeWorkTab.value = 'edit'
+}
+
+async function renameSelectedKey() {
+  if (!activeConn.value || !value.value || !redisUsable.value) return
+  const next = renameValue.value.trim()
+  if (!next) {
+    toast.error('New key name is required')
+    return
+  }
+  try {
+    const previous = value.value.key
+    await renameKey(activeConn.value.id, previous, next, selectedDb.value)
+    toast.success('Redis key renamed')
+    renameOpen.value = false
+    selectedKey.value = next
+    await loadKeys(true)
+    await openKey(next)
+  } catch {
+    toast.error('Failed to rename Redis key')
+  }
+}
+
+async function openMoveForm() {
+  if (!value.value) return
+  moveTargetDb.value = selectedDb.value === 0 ? 1 : 0
+  moveOverwrite.value = false
+  moveOpen.value = true
+  editorOpen.value = false
+  renameOpen.value = false
+  activeWorkTab.value = 'edit'
+}
+
+async function moveSelectedKey() {
+  if (!activeConn.value || !value.value || !redisUsable.value) return
+  const target = Number(moveTargetDb.value)
+  if (!Number.isFinite(target) || target < 0) {
+    toast.error('Target DB must be a non-negative number')
+    return
+  }
+  if (target === selectedDb.value) {
+    toast.error('Target DB must be different')
+    return
+  }
+  const ok = await confirm(`Move "${value.value.key}" from DB ${selectedDb.value} to DB ${target}?`, 'Move Redis Key')
+  if (!ok) return
+  try {
+    await moveKey(activeConn.value.id, value.value.key, selectedDb.value, target, moveOverwrite.value)
+    toast.success('Redis key moved')
+    value.value = null
+    selectedKey.value = ''
+    moveOpen.value = false
+    await loadKeys(true)
+  } catch {
+    toast.error('Failed to move Redis key')
+  }
+}
+
+async function executeCommand() {
+  if (!activeConn.value || !redisUsable.value || !command.value.trim()) return
+  runningCommand.value = true
+  try {
+    commandResult.value = await runCommand(activeConn.value.id, command.value, selectedDb.value)
+  } catch {
+    toast.error('Redis command failed')
+  } finally {
+    runningCommand.value = false
+  }
+}
+
+async function generateKeyScript() {
+  if (!activeConn.value || !value.value || !redisUsable.value) return
+  generatingScript.value = true
+  try {
+    scriptText.value = await generateScript(activeConn.value.id, { key: value.value.key, db: selectedDb.value })
+    scriptResults.value = []
+    activeWorkTab.value = 'script'
+  } catch {
+    toast.error('Failed to generate Redis script')
+  } finally {
+    generatingScript.value = false
+  }
+}
+
+async function generatePatternScript() {
+  if (!activeConn.value || !redisUsable.value) return
+  generatingScript.value = true
+  try {
+    scriptText.value = await generateScript(activeConn.value.id, { pattern: pattern.value || '*', db: selectedDb.value })
+    scriptResults.value = []
+    activeWorkTab.value = 'script'
+  } catch {
+    toast.error('Failed to generate Redis script')
+  } finally {
+    generatingScript.value = false
+  }
+}
+
+async function scrollToPanel(panel: { value: HTMLElement | null }) {
+  await nextTick()
+  panel.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+async function runGeneratedScript() {
+  if (!activeConn.value || !redisUsable.value || !scriptText.value.trim()) return
+  const ok = await confirm('Run this Redis script against the selected connection?', 'Run Redis Script')
+  if (!ok) return
+  runningScript.value = true
+  try {
+    scriptResults.value = await executeScript(activeConn.value.id, scriptText.value, selectedDb.value)
+    const failed = scriptResults.value.find(r => r.error)
+    if (failed) toast.error(`Script stopped at line ${failed.line}`)
+    else {
+      toast.success('Redis script executed')
+      await loadKeys(true)
+      if (selectedKey.value) await openKey(selectedKey.value).catch(() => {})
+    }
+  } catch {
+    toast.error('Failed to execute Redis script')
+  } finally {
+    runningScript.value = false
+  }
+}
+
+async function selectRedisConnection(rawId: string | number) {
+  const id = Number(rawId)
+  if (!Number.isFinite(id)) return
+  emit('set-conn', id)
+}
+
+function resetRedisWorkspace() {
+  keyLoadSeq++
+  valueLoadSeq++
+  keys.value = []
+  value.value = null
+  selectedKey.value = ''
+  cursor.value = '0'
+  loadingKeys.value = false
+  loadingValue.value = false
+}
+
+function disconnectRedis() {
+  redisConnected.value = false
+  connectionError.value = 'Disconnected'
+  lastPingMs.value = null
+  resetRedisWorkspace()
+  toast.success('Redis disconnected')
+}
+
+async function reconnectRedis(showToast = true) {
+  if (!activeConn.value || !isRedis.value) return
+  reconnecting.value = true
+  connectionError.value = ''
+  try {
+    const result = await ping(activeConn.value.id, selectedDb.value)
+    redisConnected.value = true
+    lastPingMs.value = result.latency_ms
+    await loadKeys(true)
+    if (showToast) toast.success(`Redis reconnected (${result.latency_ms}ms)`)
+  } catch {
+    redisConnected.value = false
+    resetRedisWorkspace()
+    connectionError.value = 'Redis connection failed'
+    if (showToast) toast.error('Failed to reconnect Redis')
+  } finally {
+    reconnecting.value = false
+  }
+}
+
+function ttlLabel(ttl: number) {
+  if (ttl === -2) return 'missing'
+  if (ttl === -1) return 'no expiry'
+  if (ttl < 60) return `${ttl}s`
+  if (ttl < 3600) return `${Math.floor(ttl / 60)}m`
+  return `${Math.floor(ttl / 3600)}h`
+}
+
+function formatValue(raw: unknown) {
+  if (typeof raw === 'string') return raw
+  return JSON.stringify(raw, null, 2)
+}
+
+function valueRows(raw: unknown) {
+  if (raw == null) return []
+  if (Array.isArray(raw)) {
+    return raw.map((item, index) => ({ key: String(index), value: typeof item === 'string' ? item : JSON.stringify(item) }))
+  }
+  if (typeof raw === 'object') {
+    return Object.entries(raw as Record<string, unknown>).map(([key, item]) => ({
+      key,
+      value: typeof item === 'string' ? item : JSON.stringify(item),
+    }))
+  }
+  return [{ key: 'value', value: String(raw) }]
+}
+
+function writableType(raw: string): RedisWritableType {
+  const normalized = raw === 'ReJSON-RL' ? 'json' : raw
+  return redisTypes.some(t => t.value === normalized) ? normalized as RedisWritableType : 'string'
+}
+
+function parseEditorValue() {
+  if (formType.value === 'string') return formValue.value
+  try {
+    return JSON.parse(formValue.value)
+  } catch {
+    throw new Error('Value must be valid JSON for this Redis type')
+  }
+}
+
+function valuePlaceholder(type: RedisWritableType) {
+  switch (type) {
+    case 'string':
+      return 'plain text value'
+    case 'hash':
+      return '{\n  "field": "value"\n}'
+    case 'list':
+    case 'set':
+      return '[\n  "item-1",\n  "item-2"\n]'
+    case 'zset':
+      return '[\n  { "member": "item-1", "score": 1 },\n  { "member": "item-2", "score": 2 }\n]'
+    case 'stream':
+      return '{\n  "field": "value"\n}'
+    case 'json':
+      return '{\n  "name": "Anveesa",\n  "enabled": true\n}'
+  }
+}
+
+function quoteCommandArg(value: string) {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+}
+</script>
+
+<template>
+  <div class="redis-workbench">
+    <section v-if="!isRedis" class="page-panel redis-empty">
+      <div class="redis-empty__title">No Redis connection selected</div>
+      <div v-if="redisConnections.length" class="redis-picker">
+        <label class="form-label">Redis Connection</label>
+        <select class="base-input" @change="selectRedisConnection(($event.target as HTMLSelectElement).value)">
+          <option value="">Select Redis connection</option>
+          <option v-for="conn in redisConnections" :key="conn.id" :value="conn.id">
+            {{ conn.name }} - {{ conn.host }}:{{ conn.port }}
+          </option>
+        </select>
+      </div>
+      <div v-else class="redis-empty__sub">Create a Redis connection in Admin / Connections first.</div>
+    </section>
+
+    <template v-else>
+      <aside class="redis-left">
+        <div class="redis-panel-title">
+          <span>Explorer</span>
+          <button class="icon-btn" :disabled="loadingKeys || !redisUsable" title="Refresh keys" @click="loadKeys(true)">↻</button>
+        </div>
+
+        <div class="redis-left__top">
+          <div class="redis-conn">
+            <span class="redis-conn__badge">RD</span>
+            <div>
+              <div class="redis-conn__name">{{ activeConn?.name }}</div>
+              <div class="redis-conn__sub">{{ activeConn?.host }}:{{ activeConn?.port }}</div>
+              <div class="redis-conn__state" :class="{ 'is-offline': !redisConnected }">
+                {{ redisConnected ? `Connected${lastPingMs !== null ? ` / ${lastPingMs}ms` : ''}` : connectionError || 'Disconnected' }}
+              </div>
+            </div>
+          </div>
+          <select v-model.number="selectedDb" class="base-input redis-db-select" :disabled="reconnecting" title="Redis database index">
+            <option v-for="db in redisDbIndexes" :key="db" :value="db">DB {{ db }}</option>
+          </select>
+        </div>
+
+        <div class="redis-db-tree">
+          <div class="redis-tree-root">
+            <span class="redis-tree-caret">▾</span>
+            <span class="redis-tree-icon">◉</span>
+            <span class="redis-tree-name">{{ activeConn?.name }}</span>
+          </div>
+          <div class="redis-tree-db">
+            <span class="redis-tree-caret">▾</span>
+            <span class="redis-tree-icon">▤</span>
+            <span>Database {{ selectedDb }}</span>
+            <span class="redis-tree-count">{{ keys.length }}</span>
+          </div>
+          <div class="redis-type-strip">
+            <span v-for="item in keyTypeCounts" :key="item.type">{{ item.type }} {{ item.count }}</span>
+          </div>
+        </div>
+
+        <div class="redis-searchbar">
+          <input v-model="pattern" class="base-input" :disabled="!redisUsable" placeholder="Filter keys" @keydown.enter="loadKeys(true)" />
+          <button class="icon-btn" :disabled="loadingKeys || !redisUsable" title="Scan keys" @click="loadKeys(true)">↻</button>
+        </div>
+
+        <div class="redis-sidebar-actions">
+          <button class="base-btn base-btn--primary base-btn--sm" :disabled="!redisUsable" @click="openCreateForm">New</button>
+          <button class="base-btn base-btn--ghost base-btn--sm" :disabled="!redisUsable" @click="treeMode = !treeMode">{{ treeMode ? 'Flat' : 'Tree' }}</button>
+          <button class="base-btn base-btn--ghost base-btn--sm" :disabled="generatingScript || !redisUsable" @click="generatePatternScript">Script</button>
+          <button v-if="redisConnected" class="base-btn base-btn--ghost base-btn--sm" :disabled="reconnecting" @click="disconnectRedis">Disconnect</button>
+          <button v-else class="base-btn base-btn--primary base-btn--sm" :disabled="reconnecting" @click="reconnectRedis(true)">{{ reconnecting ? 'Connecting...' : 'Reconnect' }}</button>
+        </div>
+
+        <div v-if="!redisConnected" class="redis-disconnected">
+          <div class="redis-empty__title">Redis is disconnected</div>
+          <div class="redis-empty__sub">Reconnect to scan keys and run commands for DB {{ selectedDb }}.</div>
+          <button class="base-btn base-btn--primary base-btn--sm" :disabled="reconnecting" @click="reconnectRedis(true)">{{ reconnecting ? 'Connecting...' : 'Reconnect' }}</button>
+        </div>
+
+        <div v-else-if="treeMode" class="redis-key-list redis-key-list--tree">
+          <div v-for="group in keyGroups" :key="group.name" class="redis-tree-group">
+            <div class="redis-tree-group__head">
+              <span>▾ {{ group.name }}</span>
+              <span>{{ group.items.length }}</span>
+            </div>
+            <button
+              v-for="item in group.items"
+              :key="item.key"
+              class="redis-key redis-key--nested"
+              :class="{ 'is-active': selectedKey === item.key }"
+              @click="openKey(item.key)"
+            >
+              <span class="redis-key__name">{{ item.key.includes(':') ? item.key.slice(item.key.indexOf(':') + 1) : item.key }}</span>
+              <span class="redis-key__meta">{{ item.type }} / {{ ttlLabel(item.ttl) }}</span>
+            </button>
+          </div>
+          <div v-if="!loadingKeys && keys.length === 0" class="redis-muted">No keys found.</div>
+        </div>
+
+        <div v-else class="redis-key-list">
+          <button
+            v-for="item in keys"
+            :key="item.key"
+            class="redis-key"
+            :class="{ 'is-active': selectedKey === item.key }"
+            @click="openKey(item.key)"
+          >
+            <span class="redis-key__name">{{ item.key }}</span>
+            <span class="redis-key__meta">{{ item.type }} / {{ ttlLabel(item.ttl) }}</span>
+          </button>
+          <div v-if="!loadingKeys && keys.length === 0" class="redis-muted">No keys found.</div>
+        </div>
+
+        <button v-if="redisConnected && cursor !== '0'" class="base-btn base-btn--ghost base-btn--sm redis-more" :disabled="loadingKeys" @click="loadKeys(false)">Load more</button>
+      </aside>
+
+      <main class="redis-main">
+        <div class="redis-main-titlebar">
+          <div class="redis-breadcrumbs">
+            <span>{{ activeConn?.name }}</span>
+            <span>/</span>
+            <span>DB {{ selectedDb }}</span>
+            <span v-if="value">/</span>
+            <span v-if="value" class="redis-breadcrumbs__key">{{ value.key }}</span>
+          </div>
+          <div class="redis-main-actions">
+            <button class="base-btn base-btn--ghost base-btn--sm" :disabled="loadingKeys || !redisUsable" @click="loadKeys(true)">Refresh</button>
+            <button v-if="redisConnected" class="base-btn base-btn--ghost base-btn--sm" :disabled="reconnecting" @click="disconnectRedis">Disconnect</button>
+            <button v-else class="base-btn base-btn--primary base-btn--sm" :disabled="reconnecting" @click="reconnectRedis(true)">{{ reconnecting ? 'Connecting...' : 'Reconnect' }}</button>
+          </div>
+        </div>
+
+        <div class="redis-tabbar">
+          <button class="redis-tab" :class="{ active: activeWorkTab === 'value' }" @click="activeWorkTab = 'value'"><span>▦</span> Data</button>
+          <button class="redis-tab" :class="{ active: activeWorkTab === 'edit' }" @click="activeWorkTab = 'edit'"><span>✎</span> Edit</button>
+          <button class="redis-tab" :class="{ active: activeWorkTab === 'script' }" @click="activeWorkTab = 'script'"><span>⌘</span> Script</button>
+          <button class="redis-tab" :class="{ active: activeWorkTab === 'console' }" @click="activeWorkTab = 'console'"><span>&gt;_</span> Console</button>
+        </div>
+
+        <div v-if="!redisConnected" class="redis-offline-banner">
+          <span>{{ connectionError || 'Disconnected' }}</span>
+          <button class="base-btn base-btn--primary base-btn--sm" :disabled="reconnecting" @click="reconnectRedis(true)">{{ reconnecting ? 'Connecting...' : 'Reconnect' }}</button>
+        </div>
+
+        <section v-if="activeWorkTab === 'value'" class="redis-tabbody" :class="{ 'is-disabled': !redisConnected }">
+          <div v-if="loadingValue" class="redis-muted">Loading value...</div>
+          <template v-else-if="value">
+            <div class="redis-object-head">
+              <div>
+                <div class="redis-detail__key">{{ value.key }}</div>
+                <div class="redis-detail__meta">
+                  {{ value.type }} / {{ ttlLabel(value.ttl) }}
+                  <span v-if="value.length != null"> / {{ value.length }} item{{ value.length === 1 ? '' : 's' }}</span>
+                  <span v-if="value.truncated"> / preview</span>
+                </div>
+              </div>
+              <div class="redis-detail__actions">
+                <button class="base-btn base-btn--ghost base-btn--sm" :disabled="!redisUsable" @click="openEditForm">Edit</button>
+                <button class="base-btn base-btn--ghost base-btn--sm" :disabled="!redisUsable" @click="openRenameForm">Rename</button>
+                <button class="base-btn base-btn--ghost base-btn--sm" :disabled="!redisUsable" @click="openMoveForm">Move</button>
+                <button class="base-btn base-btn--ghost base-btn--sm" :disabled="generatingScript || !redisUsable" @click="generateKeyScript">Script</button>
+                <button class="base-btn base-btn--danger base-btn--sm" :disabled="!redisUsable" @click="removeSelectedKey">Delete</button>
+              </div>
+            </div>
+
+            <div class="redis-data-toolbar">
+              <span class="redis-data-toolbar__item">{{ value.type }}</span>
+              <span class="redis-data-toolbar__item">TTL {{ ttlLabel(value.ttl) }}</span>
+              <span v-if="value.length != null" class="redis-data-toolbar__item">{{ value.length }} row{{ value.length === 1 ? '' : 's' }}</span>
+              <span v-if="value.truncated" class="redis-data-toolbar__item">Preview</span>
+            </div>
+
+            <div class="redis-table-wrap">
+              <table class="redis-data-table">
+                <thead>
+                  <tr>
+                    <th>Key / Index</th>
+                    <th>Value</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="row in valueRows(value.value)" :key="row.key">
+                    <td>{{ row.key }}</td>
+                    <td><code>{{ row.value }}</code></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </template>
+          <div v-else class="redis-muted redis-empty-work">Select a key from the explorer.</div>
+        </section>
+
+        <section v-if="activeWorkTab === 'edit'" class="redis-tabbody" :class="{ 'is-disabled': !redisConnected }">
+          <div class="redis-editor__head">
+            <div class="redis-empty__title">{{ editingExisting ? 'Edit Redis Key' : renameOpen ? 'Rename Redis Key' : moveOpen ? 'Move Redis Key' : 'Create Redis Key' }}</div>
+          </div>
+
+          <div v-if="renameOpen" class="redis-editor__grid redis-editor__grid--rename">
+            <div class="form-group">
+              <label class="form-label">New Key</label>
+              <input v-model="renameValue" class="base-input" @keydown.enter="renameSelectedKey" />
+            </div>
+            <div class="redis-editor__actions">
+              <button class="base-btn base-btn--ghost base-btn--sm" @click="renameOpen = false">Cancel</button>
+              <button class="base-btn base-btn--primary base-btn--sm" :disabled="!redisUsable" @click="renameSelectedKey">Rename</button>
+            </div>
+          </div>
+
+          <div v-else-if="moveOpen">
+            <div class="redis-editor__grid redis-editor__grid--move">
+              <div class="form-group">
+                <label class="form-label">From DB</label>
+                <input class="base-input" :value="`DB ${selectedDb}`" disabled />
+              </div>
+              <div class="form-group">
+                <label class="form-label">Target DB</label>
+                <select v-model.number="moveTargetDb" class="base-input">
+                  <option v-for="db in redisDbIndexes" :key="db" :value="db" :disabled="db === selectedDb">DB {{ db }}</option>
+                </select>
+              </div>
+              <label class="redis-check"><input v-model="moveOverwrite" type="checkbox" />Overwrite target key</label>
+            </div>
+            <div class="redis-editor__actions">
+              <button class="base-btn base-btn--ghost base-btn--sm" @click="moveOpen = false">Cancel</button>
+              <button class="base-btn base-btn--primary base-btn--sm" :disabled="!redisUsable" @click="moveSelectedKey">Move Key</button>
+            </div>
+          </div>
+
+          <div v-else>
+            <div class="redis-editor__grid">
+              <div class="form-group">
+                <label class="form-label">Key</label>
+                <input v-model="formKey" class="base-input" :disabled="editingExisting" placeholder="app:user:1" />
+              </div>
+              <div class="form-group">
+                <label class="form-label">Type</label>
+                <select v-model="formType" class="base-input">
+                  <option v-for="type in redisTypes" :key="type.value" :value="type.value">{{ type.label }}</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">TTL Seconds</label>
+                <input v-model.number="formTTL" class="base-input" type="number" min="0" placeholder="0" />
+              </div>
+            </div>
+            <div class="redis-edit-split">
+              <div class="form-group">
+                <label class="form-label">Value</label>
+                <textarea v-model="formValue" class="base-input redis-editor__value" rows="12" :placeholder="valuePlaceholder(formType)" />
+              </div>
+              <div class="form-group">
+                <label class="form-label">Command Preview</label>
+                <pre class="redis-value redis-editor__preview">{{ commandPreview }}</pre>
+              </div>
+            </div>
+            <div class="redis-editor__actions">
+              <button class="base-btn base-btn--ghost base-btn--sm" @click="editorOpen = false">Cancel</button>
+              <button class="base-btn base-btn--primary base-btn--sm" :disabled="saving || !redisUsable" @click="saveRedisKey">{{ saving ? 'Saving...' : 'Save Key' }}</button>
+            </div>
+          </div>
+        </section>
+
+        <section v-if="activeWorkTab === 'script'" class="redis-tabbody" :class="{ 'is-disabled': !redisConnected }">
+          <div class="redis-editor__head">
+            <div class="redis-empty__title">Generated Redis Script</div>
+            <div class="redis-detail__actions">
+              <button class="base-btn base-btn--ghost base-btn--sm" :disabled="generatingScript || !redisUsable" @click="generatePatternScript">Generate Pattern</button>
+              <button class="base-btn base-btn--primary base-btn--sm" :disabled="runningScript || !scriptText || !redisUsable" @click="runGeneratedScript">{{ runningScript ? 'Running...' : 'Run Script' }}</button>
+            </div>
+          </div>
+          <textarea v-model="scriptText" class="base-input redis-editor__value redis-script-editor" rows="14" />
+          <pre v-if="scriptResults.length" class="redis-value redis-console__result">{{ formatValue(scriptResults) }}</pre>
+        </section>
+
+        <section v-if="activeWorkTab === 'console'" class="redis-tabbody" :class="{ 'is-disabled': !redisConnected }">
+          <div class="redis-empty__title">Command Console</div>
+          <div class="redis-console__row">
+            <input v-model="command" class="base-input redis-console__input" :disabled="!redisUsable" placeholder='GET "app:user:1"' @keydown.enter="executeCommand" />
+            <button class="base-btn base-btn--primary base-btn--sm" :disabled="runningCommand || !redisUsable" @click="executeCommand">{{ runningCommand ? 'Running...' : 'Run' }}</button>
+          </div>
+          <pre v-if="commandResult !== null" class="redis-value redis-console__result">{{ formatValue(commandResult) }}</pre>
+        </section>
+      </main>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.redis-workbench {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  height: 100%;
+  min-height: calc(100vh - 76px);
+  background: var(--bg-body);
+  border-top: 1px solid var(--border);
+}
+
+.redis-left {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  background: var(--bg-surface);
+  overflow: hidden;
+  box-shadow: 2px 0 12px rgba(0,0,0,.03);
+}
+
+.redis-panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg-surface) 95%, transparent);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.redis-left__top {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 68px;
+  gap: 8px;
+  padding: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.redis-conn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.redis-conn__badge {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: rgba(198, 48, 43, 0.14);
+  color: #c6302b;
+  font-size: 10px;
+  font-weight: 800;
+  flex-shrink: 0;
+}
+
+.redis-conn__name,
+.redis-conn__sub {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.redis-conn__name {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.redis-conn__sub {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 10.5px;
+}
+
+.redis-conn__state {
+  margin-top: 2px;
+  color: #21834a;
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+.redis-conn__state.is-offline {
+  color: var(--danger);
+}
+
+.redis-db-tree {
+  display: grid;
+  gap: 2px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.redis-tree-root,
+.redis-tree-db {
+  display: grid;
+  grid-template-columns: 16px 18px minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 26px;
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.redis-tree-db {
+  margin-left: 16px;
+  color: var(--text-muted);
+}
+
+.redis-tree-caret,
+.redis-tree-icon,
+.redis-tree-count {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.redis-tree-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.redis-type-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 4px 0 0 34px;
+}
+
+.redis-type-strip span {
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-body);
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+
+.redis-searchbar {
+  display: flex;
+  gap: 6px;
+  padding: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.redis-sidebar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.redis-disconnected {
+  display: grid;
+  gap: 10px;
+  margin: 10px;
+  padding: 14px;
+  border: 1px dashed var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-body);
+}
+
+.redis-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--bg-body);
+}
+
+.redis-main-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 48px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+
+.redis-breadcrumbs,
+.redis-main-actions,
+.redis-data-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.redis-breadcrumbs {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.redis-breadcrumbs__key {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+.redis-tabbar {
+  display: flex;
+  gap: 0;
+  min-height: 32px;
+  padding: 0 4px;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.redis-tabbar::-webkit-scrollbar {
+  display: none;
+}
+
+.redis-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 32px;
+  padding: 0 10px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.redis-tab.active {
+  background: var(--bg-surface);
+  border-bottom-color: var(--brand);
+  color: var(--text-primary);
+}
+
+.redis-offline-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--danger) 8%, var(--bg-surface));
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.redis-tabbody {
+  min-height: 0;
+  padding: 0;
+  overflow: auto;
+}
+
+.redis-tabbody.is-disabled {
+  opacity: 0.72;
+}
+
+.redis-object-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 48px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+
+.redis-data-toolbar {
+  min-height: 36px;
+  padding: 6px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+
+.redis-data-toolbar__item {
+  padding: 3px 7px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-body);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.redis-table-wrap {
+  min-height: 0;
+  overflow: auto;
+}
+
+.redis-data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 12.5px;
+}
+
+.redis-data-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-align: left;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.redis-data-table tbody tr:hover td {
+  background: var(--bg-hover);
+}
+
+.redis-data-table tbody tr:nth-child(even) td {
+  background: rgba(255,255,255,0.01);
+}
+
+html[data-theme='light'] .redis-data-table tbody tr:nth-child(even) td {
+  background: rgba(0,0,0,0.01);
+}
+
+.redis-data-table tbody td {
+  max-width: 520px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.redis-data-table tbody td:first-child {
+  width: 240px;
+  max-width: 260px;
+  color: var(--text-muted);
+}
+
+.redis-data-table code {
+  font-family: var(--mono);
+  font-size: 12.5px;
+}
+
+.redis-empty-work {
+  padding: 28px;
+}
+
+.redis-edit-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
+  gap: 12px;
+}
+
+.redis-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 380px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.redis-keys,
+.redis-detail,
+.redis-empty {
+  padding: 16px;
+}
+
+.redis-toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.redis-db-select {
+  width: 68px;
+  height: 28px;
+  padding: 0 6px;
+  flex-shrink: 0;
+  font-size: 11px;
+}
+
+.redis-key-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  max-height: none;
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  padding: 4px 0;
+}
+
+.redis-key {
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  padding: 6px 10px 6px 18px;
+  border: 1px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.redis-key:hover,
+.redis-key.is-active {
+  border-color: transparent;
+  background: color-mix(in srgb, var(--brand) 11%, var(--bg-surface));
+}
+
+.redis-key--nested {
+  margin-top: 0;
+  padding-left: 28px;
+}
+
+.redis-tree-group {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 4px;
+}
+
+.redis-tree-group__head {
+  display: flex;
+  justify-content: space-between;
+  padding: 7px 10px;
+  background: color-mix(in srgb, var(--bg-body) 72%, var(--bg-surface));
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.redis-key__name,
+.redis-detail__key {
+  font-family: var(--mono);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.redis-key__meta,
+.redis-detail__meta,
+.redis-muted,
+.redis-empty__sub {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.redis-more {
+  width: 100%;
+  justify-content: center;
+  margin: 6px 0 10px;
+}
+
+.redis-detail__head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.redis-detail__actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.redis-value {
+  margin: 0;
+  min-height: 260px;
+  max-height: calc(100vh - 285px);
+  overflow: auto;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-body);
+  color: var(--text-primary);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.redis-empty__title {
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.redis-picker {
+  max-width: 360px;
+  margin-top: 12px;
+}
+
+.redis-editor {
+  padding: 16px;
+}
+
+.redis-editor__head,
+.redis-editor__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.redis-editor__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 160px 140px;
+  gap: 10px;
+  margin: 12px 0;
+}
+
+.redis-editor__grid--rename {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+}
+
+.redis-editor__grid--move {
+  grid-template-columns: 1fr 1fr auto;
+  align-items: end;
+}
+
+.redis-editor__value {
+  font-family: var(--mono);
+  font-size: 12px;
+  resize: vertical;
+}
+
+.redis-editor__preview {
+  min-height: 86px;
+  max-height: 160px;
+}
+
+.redis-editor__actions {
+  justify-content: flex-end;
+}
+
+.redis-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.redis-console {
+  padding: 16px;
+}
+
+.redis-console__row {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.redis-console__input {
+  font-family: var(--mono);
+}
+
+.redis-console__result {
+  min-height: 120px;
+  margin-top: 12px;
+}
+
+.redis-script-editor {
+  margin-top: 12px;
+  min-height: 220px;
+}
+
+@media (max-width: 900px) {
+  .redis-workbench {
+    grid-template-columns: 1fr;
+  }
+
+  .redis-left {
+    min-height: 360px;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .redis-edit-split {
+    grid-template-columns: 1fr;
+  }
+
+  .redis-data-table tbody td {
+    max-width: 220px;
+  }
+
+  .redis-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .redis-editor__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .redis-editor__grid--rename,
+  .redis-editor__grid--move,
+  .redis-console__row {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary

Add Redis database browser support to Anveesa Nias, enabling users to
visually explore and query Redis data structures through the UI.

This change introduces a Redis connection manager and key explorer that
supports all major Redis data types: **Hash**, **List**, **Set**,
**Sorted Set (ZSet)**, **Stream**, and **String**. Users can browse keys
grouped by namespace prefix, view data inline, and execute raw Redis
commands via a built-in Command Console.

Key capabilities added:
- Connect to a Redis instance (e.g. `localhost:6379`) and browse DB indexes
- View key metadata: type, TTL, and row count
- Inspect key values per data type (e.g. `HGETALL`, `ZREVRANGE`, `XRANGE`)
- Execute arbitrary Redis commands from the Console tab
- Namespace-aware key grouping (e.g. `user:*`, `events:*`, `queue:*`)

## Verification

- `cd server && go test ./...`
- `cd web && npm run build`
- Manual UI verification:
  - Connected to `local-redis-1` at `localhost:6379`
  - Browsed all 6 keys across multiple data types in DB 0
  - Verified Hash (`user:1`): fields `name`, `role`, `email` returned correctly via `HGETALL user:1`
  - Verified ZSet (`leaderboard`): top members returned in score order via `ZREVRANGE leaderboard 0 2 WITHSCORES`
  - Verified Stream (`events:login`): entry with `action`, `ip`, `user_id` fields visible in Data tab
  - Verified Console tab executes raw commands and renders JSON output

## Checklist

- [x] The change is focused and reviewable.
- [x] Documentation was updated when behavior or configuration changed.
- [x] No secrets, local databases, logs, or generated build output are committed.
- [x] Security and permission impact was considered.

## Screenshots

### Key Explorer — Hash (`user:1`)
<img width="1430" height="848" alt="Screenshot 2026-05-08 at 23 29 28" src="https://github.com/user-attachments/assets/5e92913f-736d-476d-a2d1-6978b50bf443" />

### Key Explorer — Sorted Set (`leaderboard`)
<img width="1429" height="849" alt="Screenshot 2026-05-08 at 23 29 43" src="https://github.com/user-attachments/assets/6dc51e04-5b59-400a-9ce8-80521906aed8" />

### Key Explorer — Stream (`events:login`)
<img width="1430" height="848" alt="Screenshot 2026-05-08 at 23 31 30" src="https://github.com/user-attachments/assets/322e7e85-734b-4718-bc16-494f37efa9db" />

### Command Console — `HGETALL user:1`
<img width="1429" height="848" alt="Screenshot 2026-05-08 at 23 32 16" src="https://github.com/user-attachments/assets/c30e3c1a-1f9e-4db9-8c46-5ea1310dfde6" />

### Command Console — `ZREVRANGE leaderboard 0 2 WITHSCORES`
<img width="1429" height="848" alt="Screenshot 2026-05-08 at 23 32 43" src="https://github.com/user-attachments/assets/68a10f0d-f193-40aa-895b-fbdea19c498f" />
