### PR TITLE
feat: create redis pub/sub client for laravel queue

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/anveesa/nias/config"
 	"github.com/go-sql-driver/mysql"
@@ -36,7 +37,7 @@ func Init(cfg *config.Config) error {
 		// Configure connection pool for PostgreSQL
 		db.SetMaxOpenConns(25)
 		db.SetMaxIdleConns(5)
-		db.SetConnMaxLifetime(0)
+		db.SetConnMaxLifetime(5 * time.Minute)
 
 		// Test connection
 		if err := db.Ping(); err != nil {
@@ -60,7 +61,7 @@ func Init(cfg *config.Config) error {
 		// Configure connection pool for MySQL
 		db.SetMaxOpenConns(25)
 		db.SetMaxIdleConns(5)
-		db.SetConnMaxLifetime(0)
+		db.SetConnMaxLifetime(3 * time.Minute)
 
 		// Test connection
 		if err := db.Ping(); err != nil {
@@ -117,7 +118,8 @@ func ConvertQuery(query string) string {
 	}
 
 	// Convert ? to $1, $2, $3, etc.
-	result := ""
+	var buf strings.Builder
+	buf.Grow(len(query))
 	paramCount := 1
 	inQuote := false
 	quoteChar := byte(0)
@@ -137,12 +139,14 @@ func ConvertQuery(query string) string {
 
 		// Only replace ? outside of string literals
 		if ch == '?' && !inQuote {
-			result += "$" + strconv.Itoa(paramCount)
+			buf.WriteByte('$')
+			buf.WriteString(strconv.Itoa(paramCount))
 			paramCount++
 		} else {
-			result += string(ch)
+			buf.WriteByte(ch)
 		}
 	}
+	result := buf.String()
 
 	// Add ON CONFLICT DO NOTHING for PostgreSQL/MySQL if original had INSERT OR IGNORE
 	if hasInsertOrIgnore && (IsPostgreSQL() || IsMySQL()) {
@@ -365,6 +369,54 @@ func migrate() error {
 		)`,
 		`CREATE INDEX IF NOT EXISTS idx_notification_deliveries_pending ON notification_deliveries(status, next_attempt_at, created_at)`,
 		`CREATE INDEX IF NOT EXISTS idx_notification_deliveries_event ON notification_deliveries(event_id, created_at DESC)`,
+		`CREATE TABLE IF NOT EXISTS laravel_queue_profiles (
+			id            INTEGER PRIMARY KEY AUTOINCREMENT,
+			conn_id       INTEGER NOT NULL,
+			environment   TEXT NOT NULL DEFAULT 'default',
+			settings_json TEXT NOT NULL DEFAULT '{}',
+			created_by    INTEGER NOT NULL DEFAULT 0,
+			updated_by    INTEGER NOT NULL DEFAULT 0,
+			created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(conn_id, environment)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_laravel_queue_profiles_conn ON laravel_queue_profiles(conn_id, environment)`,
+		`CREATE TABLE IF NOT EXISTS laravel_queue_audit (
+			id             INTEGER PRIMARY KEY AUTOINCREMENT,
+			conn_id        INTEGER NOT NULL DEFAULT 0,
+			failed_conn_id INTEGER NOT NULL DEFAULT 0,
+			user_id        INTEGER NOT NULL DEFAULT 0,
+			username       TEXT NOT NULL DEFAULT '',
+			action         TEXT NOT NULL DEFAULT '',
+			queue          TEXT NOT NULL DEFAULT '',
+			target_queue   TEXT NOT NULL DEFAULT '',
+			job_uuid       TEXT NOT NULL DEFAULT '',
+			failed_job_id  INTEGER NOT NULL DEFAULT 0,
+			payload_edited INTEGER NOT NULL DEFAULT 0,
+			status         TEXT NOT NULL DEFAULT 'success',
+			error          TEXT NOT NULL DEFAULT '',
+			details_json   TEXT NOT NULL DEFAULT '{}',
+			created_at     DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_laravel_queue_audit_conn_time ON laravel_queue_audit(conn_id, created_at DESC)`,
+		`CREATE TABLE IF NOT EXISTS laravel_queue_quarantine (
+			id             INTEGER PRIMARY KEY AUTOINCREMENT,
+			conn_id        INTEGER NOT NULL DEFAULT 0,
+			failed_conn_id INTEGER NOT NULL DEFAULT 0,
+			failed_job_id  INTEGER NOT NULL DEFAULT 0,
+			uuid           TEXT NOT NULL DEFAULT '',
+			queue          TEXT NOT NULL DEFAULT '',
+			job_name       TEXT NOT NULL DEFAULT '',
+			payload        TEXT NOT NULL DEFAULT '',
+			exception      TEXT NOT NULL DEFAULT '',
+			reason         TEXT NOT NULL DEFAULT '',
+			status         TEXT NOT NULL DEFAULT 'quarantined',
+			created_by     INTEGER NOT NULL DEFAULT 0,
+			created_at     DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at     DATETIME DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(conn_id, failed_conn_id, failed_job_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_laravel_queue_quarantine_conn ON laravel_queue_quarantine(conn_id, status, created_at DESC)`,
 		`CREATE TABLE IF NOT EXISTS auth_sessions (
 			id           INTEGER PRIMARY KEY AUTOINCREMENT,
 			user_id      INTEGER NOT NULL,
@@ -898,12 +950,7 @@ func migrate() error {
 }
 
 func isAlterAdd(s string) bool {
-	u := len(s)
-	if u > 30 {
-		u = 30
-	}
-	upper := s[:u]
-	return len(upper) > 5 && upper[:5] == "ALTER"
+	return strings.HasPrefix(s, "ALTER")
 }
 
 // Ping checks if the database is accessible
@@ -939,11 +986,8 @@ func seedDefaultAdmin() error {
 	var roleCount int
 	DB.QueryRow(`SELECT COUNT(*) FROM roles WHERE id = 1`).Scan(&roleCount)
 	if roleCount == 0 {
-		// Create admin role
-		if IsPostgreSQL() || IsMySQL() {
-			DB.Exec(`INSERT INTO roles (id, name, description, is_system) VALUES (1, 'Admin', 'Full system access', 1)`)
-		} else {
-			DB.Exec(`INSERT INTO roles (id, name, description, is_system) VALUES (1, 'Admin', 'Full system access', 1)`)
+		if _, err := DB.Exec(ConvertQuery(`INSERT INTO roles (id, name, description, is_system) VALUES (?, 'Admin', 'Full system access', 1)`), 1); err != nil {
+			fmt.Printf("Warning: could not create admin role: %v\n", err)
 		}
 	}
 

--- a/server/handlers/dashboard.go
+++ b/server/handlers/dashboard.go
@@ -93,6 +93,15 @@ func GetDashboard() http.HandlerFunc {
 			return
 		}
 
+		// Check the driver before attempting a SQL connection — Redis connections
+		// have no SQL DSN and must return a minimal response rather than a 502.
+		var rawDriver string
+		_ = appdb.DB.QueryRow(appdb.ConvertQuery(`SELECT driver FROM connections WHERE id=?`), connID).Scan(&rawDriver)
+		if rawDriver == "redis" {
+			json.NewEncoder(w).Encode(DashboardData{Driver: "redis", Tables: []TableStat{}, SlowQueries: SlowQuerySummary{Queries: []SlowQueryStat{}}})
+			return
+		}
+
 		db, driver, err := GetDB(connID)
 		if err != nil {
 			http.Error(w, jsonError(err.Error()), http.StatusBadGateway)

--- a/server/handlers/laravel_queue.go
+++ b/server/handlers/laravel_queue.go
@@ -1,0 +1,627 @@
+package handlers
+
+import (
+	"crypto/sha1"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type laravelQueueSummary struct {
+	Name     string `json:"name"`
+	Ready    int64  `json:"ready"`
+	Delayed  int64  `json:"delayed"`
+	Reserved int64  `json:"reserved"`
+	Notify   bool   `json:"notify"`
+}
+
+type laravelQueueJob struct {
+	ID          string         `json:"id"`
+	State       string         `json:"state"`
+	Queue       string         `json:"queue"`
+	UUID        string         `json:"uuid,omitempty"`
+	DisplayName string         `json:"display_name,omitempty"`
+	Job         string         `json:"job,omitempty"`
+	CommandName string         `json:"command_name,omitempty"`
+	Attempts    int64          `json:"attempts"`
+	MaxTries    int64          `json:"max_tries,omitempty"`
+	Timeout     int64          `json:"timeout,omitempty"`
+	Backoff     any            `json:"backoff,omitempty"`
+	Score       int64          `json:"score,omitempty"`
+	AvailableAt string         `json:"available_at,omitempty"`
+	Payload     map[string]any `json:"payload,omitempty"`
+	Raw         string         `json:"raw"`
+}
+
+type laravelQueueJobsResponse struct {
+	Queue string            `json:"queue"`
+	Jobs  []laravelQueueJob `json:"jobs"`
+}
+
+type laravelQueueActionRequest struct {
+	Queue  string `json:"queue"`
+	Prefix string `json:"prefix"`
+	State  string `json:"state"`
+	Raw    string `json:"raw"`
+	DB     *int   `json:"db"`
+}
+
+type laravelFailedJob struct {
+	ID         int64          `json:"id"`
+	UUID       string         `json:"uuid,omitempty"`
+	Connection string         `json:"connection"`
+	Queue      string         `json:"queue"`
+	Payload    map[string]any `json:"payload,omitempty"`
+	RawPayload string         `json:"raw_payload"`
+	Exception  string         `json:"exception"`
+	FailedAt   string         `json:"failed_at"`
+}
+
+type laravelFailedJobActionRequest struct {
+	ID            int64  `json:"id"`
+	RedisConnID   int64  `json:"redis_conn_id"`
+	RedisDB       *int   `json:"redis_db"`
+	Prefix        string `json:"prefix"`
+	Queue         string `json:"queue"`
+	Payload       string `json:"payload"`
+	DeleteAfter   bool   `json:"delete_after"`
+	PayloadEdited bool   `json:"payload_edited"`
+}
+
+type laravelHorizonSummary struct {
+	Detected    bool             `json:"detected"`
+	KeyCount    int              `json:"key_count"`
+	Supervisors int64            `json:"supervisors"`
+	Masters     int64            `json:"masters"`
+	RecentJobs  int64            `json:"recent_jobs"`
+	FailedJobs  int64            `json:"failed_jobs"`
+	Workload    map[string]int64 `json:"workload,omitempty"`
+	SampleKeys  []string         `json:"sample_keys"`
+}
+
+func LaravelQueueQueues() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		client, connName, err := openRedisClient(connID, redisDBFromRequest(r))
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		prefix := laravelQueuePrefix(r)
+		keys, err := scanRedisKeys(r.Context(), client, prefix+":*", 1000)
+		if err != nil {
+			http.Error(w, jsonError("redis scan failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+
+		names := map[string]bool{}
+		for _, key := range keys {
+			if name := laravelQueueNameFromKey(prefix, key); name != "" {
+				names[name] = true
+			}
+		}
+		if len(names) == 0 {
+			names["default"] = true
+		}
+
+		summaries := make([]laravelQueueSummary, 0, len(names))
+		for name := range names {
+			ready, _ := redisInt(client.command(r.Context(), "LLEN", laravelQueueKey(prefix, name, "")))
+			delayed, _ := redisInt(client.command(r.Context(), "ZCARD", laravelQueueKey(prefix, name, "delayed")))
+			reserved, _ := redisInt(client.command(r.Context(), "ZCARD", laravelQueueKey(prefix, name, "reserved")))
+			notify, _ := redisInt(client.command(r.Context(), "EXISTS", laravelQueueKey(prefix, name, "notify")))
+			summaries = append(summaries, laravelQueueSummary{
+				Name:     name,
+				Ready:    ready,
+				Delayed:  delayed,
+				Reserved: reserved,
+				Notify:   notify > 0,
+			})
+		}
+		sort.Slice(summaries, func(i, j int) bool { return summaries[i].Name < summaries[j].Name })
+		writeRedisAudit(r, "laravel_queue_list", connID, connName, prefix, "")
+		json.NewEncoder(w).Encode(summaries)
+	}
+}
+
+func LaravelQueueJobs() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		queue := strings.TrimSpace(r.URL.Query().Get("queue"))
+		if queue == "" {
+			queue = "default"
+		}
+		client, connName, err := openRedisClient(connID, redisDBFromRequest(r))
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		prefix := laravelQueuePrefix(r)
+		limit := queryInt(r, "limit", 100, 1, 500)
+		jobs := make([]laravelQueueJob, 0, limit)
+
+		readyRaw, err := client.command(r.Context(), "LRANGE", laravelQueueKey(prefix, queue, ""), "0", strconv.Itoa(limit-1))
+		if err != nil {
+			http.Error(w, jsonError("redis lrange failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+		for _, raw := range anySliceToStrings(readyRaw) {
+			jobs = append(jobs, parseLaravelQueueJob(raw, queue, "ready", 0))
+		}
+
+		for _, state := range []string{"delayed", "reserved"} {
+			raw, err := client.command(r.Context(), "ZRANGE", laravelQueueKey(prefix, queue, state), "0", strconv.Itoa(limit-1), "WITHSCORES")
+			if err != nil {
+				http.Error(w, jsonError("redis zrange failed: "+err.Error()), http.StatusBadGateway)
+				return
+			}
+			for _, pair := range zsetPairs(raw) {
+				score, _ := strconv.ParseInt(pair["score"], 10, 64)
+				jobs = append(jobs, parseLaravelQueueJob(pair["member"], queue, state, score))
+			}
+		}
+
+		writeRedisAudit(r, "laravel_queue_jobs", connID, connName, queue, "")
+		json.NewEncoder(w).Encode(laravelQueueJobsResponse{Queue: queue, Jobs: jobs})
+	}
+}
+
+func LaravelQueueAction() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/connections/"), "/")
+		action := ""
+		if len(parts) >= 4 {
+			action = parts[3]
+		}
+
+		var payload laravelQueueActionRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		payload.Queue = strings.TrimSpace(payload.Queue)
+		if payload.Queue == "" {
+			payload.Queue = "default"
+		}
+		payload.Prefix = strings.Trim(strings.TrimSpace(payload.Prefix), ":")
+		if payload.Prefix == "" {
+			payload.Prefix = "queues"
+		}
+
+		client, connName, err := openRedisClient(connID, payload.DB)
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		switch action {
+		case "delete":
+			if err := enforceLaravelQueueAction(connID, "delete"); err != nil {
+				writeLaravelQueueAudit(r, connID, 0, "delete", payload.Queue, "", "", 0, false, "blocked", err.Error(), nil)
+				http.Error(w, jsonError(err.Error()), http.StatusForbidden)
+				return
+			}
+			if err := laravelQueueRemoveJob(r, client, payload); err != nil {
+				writeRedisAudit(r, "laravel_queue_delete", connID, connName, payload.Queue, err.Error())
+				writeLaravelQueueAudit(r, connID, 0, "delete", payload.Queue, "", "", 0, false, "failed", err.Error(), map[string]any{"state": payload.State})
+				http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+				return
+			}
+			writeRedisAudit(r, "laravel_queue_delete", connID, connName, payload.Queue, "")
+			writeLaravelQueueAudit(r, connID, 0, "delete", payload.Queue, "", "", 0, false, "success", "", map[string]any{"state": payload.State})
+			json.NewEncoder(w).Encode(map[string]string{"message": "Job deleted"})
+		case "requeue":
+			if err := enforceLaravelQueueAction(connID, "retry"); err != nil {
+				writeLaravelQueueAudit(r, connID, 0, "requeue", payload.Queue, payload.Queue, "", 0, false, "blocked", err.Error(), nil)
+				http.Error(w, jsonError(err.Error()), http.StatusForbidden)
+				return
+			}
+			if payload.Raw == "" {
+				http.Error(w, `{"error":"job payload is required"}`, http.StatusBadRequest)
+				return
+			}
+			if payload.State != "delayed" && payload.State != "reserved" {
+				http.Error(w, `{"error":"only delayed or reserved jobs can be requeued"}`, http.StatusBadRequest)
+				return
+			}
+			if err := laravelQueueRemoveJob(r, client, payload); err != nil {
+				writeRedisAudit(r, "laravel_queue_requeue", connID, connName, payload.Queue, err.Error())
+				writeLaravelQueueAudit(r, connID, 0, "requeue", payload.Queue, payload.Queue, "", 0, false, "failed", err.Error(), map[string]any{"state": payload.State})
+				http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+				return
+			}
+			if _, err := client.command(r.Context(), "LPUSH", laravelQueueKey(payload.Prefix, payload.Queue, ""), payload.Raw); err != nil {
+				writeRedisAudit(r, "laravel_queue_requeue", connID, connName, payload.Queue, err.Error())
+				writeLaravelQueueAudit(r, connID, 0, "requeue", payload.Queue, payload.Queue, "", 0, false, "failed", err.Error(), map[string]any{"state": payload.State})
+				http.Error(w, jsonError("redis lpush failed: "+err.Error()), http.StatusBadGateway)
+				return
+			}
+			writeRedisAudit(r, "laravel_queue_requeue", connID, connName, payload.Queue, "")
+			writeLaravelQueueAudit(r, connID, 0, "requeue", payload.Queue, payload.Queue, "", 0, false, "success", "", map[string]any{"state": payload.State})
+			json.NewEncoder(w).Encode(map[string]string{"message": "Job requeued"})
+		case "clear":
+			if err := enforceLaravelQueueAction(connID, "clear"); err != nil {
+				writeLaravelQueueAudit(r, connID, 0, "clear", payload.Queue, "", "", 0, false, "blocked", err.Error(), map[string]any{"state": payload.State})
+				http.Error(w, jsonError(err.Error()), http.StatusForbidden)
+				return
+			}
+			keys := []string{}
+			switch payload.State {
+			case "ready":
+				keys = append(keys, laravelQueueKey(payload.Prefix, payload.Queue, ""))
+			case "delayed", "reserved", "notify":
+				keys = append(keys, laravelQueueKey(payload.Prefix, payload.Queue, payload.State))
+			default:
+				keys = append(keys,
+					laravelQueueKey(payload.Prefix, payload.Queue, ""),
+					laravelQueueKey(payload.Prefix, payload.Queue, "delayed"),
+					laravelQueueKey(payload.Prefix, payload.Queue, "reserved"),
+					laravelQueueKey(payload.Prefix, payload.Queue, "notify"),
+				)
+			}
+			args := append([]string{"DEL"}, keys...)
+			if _, err := client.command(r.Context(), args...); err != nil {
+				writeRedisAudit(r, "laravel_queue_clear", connID, connName, payload.Queue, err.Error())
+				writeLaravelQueueAudit(r, connID, 0, "clear", payload.Queue, "", "", 0, false, "failed", err.Error(), map[string]any{"state": payload.State})
+				http.Error(w, jsonError("redis delete failed: "+err.Error()), http.StatusBadGateway)
+				return
+			}
+			writeRedisAudit(r, "laravel_queue_clear", connID, connName, payload.Queue, "")
+			writeLaravelQueueAudit(r, connID, 0, "clear", payload.Queue, "", "", 0, false, "success", "", map[string]any{"state": payload.State})
+			json.NewEncoder(w).Encode(map[string]string{"message": "Queue cleared"})
+		default:
+			http.Error(w, `{"error":"unsupported queue action"}`, http.StatusBadRequest)
+		}
+	}
+}
+
+func LaravelQueueFailedJobs() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		db, driver, err := openRemoteDB(connID)
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+		defer db.Close()
+
+		limit := queryInt(r, "limit", 100, 1, 500)
+		query := "SELECT id, COALESCE(uuid,''), connection, queue, payload, exception, failed_at FROM failed_jobs ORDER BY id DESC LIMIT " + strconv.Itoa(limit)
+		if driver == "sqlserver" {
+			query = "SELECT TOP " + strconv.Itoa(limit) + " id, COALESCE(uuid,''), connection, queue, payload, exception, failed_at FROM failed_jobs ORDER BY id DESC"
+		}
+
+		rows, err := db.QueryContext(r.Context(), query)
+		if err != nil {
+			http.Error(w, jsonError("failed_jobs query failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+		defer rows.Close()
+
+		jobs := []laravelFailedJob{}
+		for rows.Next() {
+			var job laravelFailedJob
+			var uuid, connection, queue, payload, exception sql.NullString
+			var failedAt any
+			if err := rows.Scan(&job.ID, &uuid, &connection, &queue, &payload, &exception, &failedAt); err != nil {
+				http.Error(w, jsonError("failed_jobs scan failed: "+err.Error()), http.StatusBadGateway)
+				return
+			}
+			job.UUID = uuid.String
+			job.Connection = connection.String
+			job.Queue = queue.String
+			job.RawPayload = payload.String
+			job.Exception = exception.String
+			job.FailedAt = fmt.Sprint(failedAt)
+			var decoded map[string]any
+			if err := json.Unmarshal([]byte(payload.String), &decoded); err == nil {
+				job.Payload = decoded
+			}
+		jobs = append(jobs, job)
+	}
+	if err := rows.Err(); err != nil {
+		http.Error(w, jsonError("failed_jobs iteration error: "+err.Error()), http.StatusBadGateway)
+		return
+	}
+	json.NewEncoder(w).Encode(jobs)
+}
+}
+
+func LaravelQueueFailedJobAction() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/connections/"), "/")
+		action := ""
+		if len(parts) >= 4 {
+			action = parts[3]
+		}
+
+		var payload laravelFailedJobActionRequest
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		if payload.ID <= 0 {
+			http.Error(w, `{"error":"failed job id is required"}`, http.StatusBadRequest)
+			return
+		}
+
+		db, driver, err := openRemoteDB(connID)
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+		defer db.Close()
+
+		switch action {
+	case "retry-failed":
+		if payload.RedisConnID <= 0 {
+			http.Error(w, `{"error":"redis connection id is required"}`, http.StatusBadRequest)
+			return
+		}
+		if err := enforceLaravelQueueAction(payload.RedisConnID, "retry"); err != nil {
+			writeLaravelQueueAudit(r, payload.RedisConnID, connID, "retry_failed", payload.Queue, payload.Queue, "", payload.ID, payload.PayloadEdited, "blocked", err.Error(), nil)
+			http.Error(w, jsonError(err.Error()), http.StatusForbidden)
+			return
+		}
+		if payload.DeleteAfter {
+			if err := enforceLaravelQueueAction(payload.RedisConnID, "delete"); err != nil {
+				writeLaravelQueueAudit(r, payload.RedisConnID, connID, "retry_failed", payload.Queue, payload.Queue, "", payload.ID, payload.PayloadEdited, "blocked", err.Error(), map[string]any{"delete_after": true})
+				http.Error(w, jsonError(err.Error()), http.StatusForbidden)
+				return
+			}
+		}
+		if payload.PayloadEdited {
+			if err := enforceLaravelQueueAction(payload.RedisConnID, "editedReplay"); err != nil {
+				writeLaravelQueueAudit(r, payload.RedisConnID, connID, "retry_failed", payload.Queue, payload.Queue, "", payload.ID, true, "blocked", err.Error(), nil)
+				http.Error(w, jsonError(err.Error()), http.StatusForbidden)
+				return
+			}
+		}
+			payload.Prefix = strings.Trim(strings.TrimSpace(payload.Prefix), ":")
+			if payload.Prefix == "" {
+				payload.Prefix = "queues"
+			}
+			payload.Queue = strings.TrimSpace(payload.Queue)
+			if payload.Queue == "" {
+				payload.Queue = "default"
+			}
+			if payload.Payload == "" {
+				http.Error(w, `{"error":"failed job payload is required"}`, http.StatusBadRequest)
+				return
+			}
+			redisClient, _, err := openRedisClient(payload.RedisConnID, payload.RedisDB)
+			if err != nil {
+				writeLaravelQueueAudit(r, payload.RedisConnID, connID, "retry_failed", payload.Queue, payload.Queue, "", payload.ID, payload.PayloadEdited, "failed", err.Error(), nil)
+				http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+				return
+			}
+			if _, err := redisClient.command(r.Context(), "LPUSH", laravelQueueKey(payload.Prefix, payload.Queue, ""), payload.Payload); err != nil {
+				writeLaravelQueueAudit(r, payload.RedisConnID, connID, "retry_failed", payload.Queue, payload.Queue, "", payload.ID, payload.PayloadEdited, "failed", err.Error(), nil)
+				http.Error(w, jsonError("redis lpush failed: "+err.Error()), http.StatusBadGateway)
+				return
+			}
+			if payload.DeleteAfter {
+				if err := deleteLaravelFailedJob(r, db, driver, payload.ID); err != nil {
+					writeLaravelQueueAudit(r, payload.RedisConnID, connID, "retry_failed", payload.Queue, payload.Queue, "", payload.ID, payload.PayloadEdited, "failed", err.Error(), map[string]any{"delete_after": true})
+					http.Error(w, jsonError(err.Error()), http.StatusBadGateway)
+					return
+				}
+			}
+			writeLaravelQueueAudit(r, payload.RedisConnID, connID, "retry_failed", payload.Queue, payload.Queue, "", payload.ID, payload.PayloadEdited, "success", "", map[string]any{"delete_after": payload.DeleteAfter})
+			json.NewEncoder(w).Encode(map[string]string{"message": "Failed job retried"})
+		case "delete-failed":
+			enforceConnID := payload.RedisConnID
+			if enforceConnID <= 0 {
+				enforceConnID = connID
+			}
+			if err := enforceLaravelQueueAction(enforceConnID, "delete"); err != nil {
+				writeLaravelQueueAudit(r, enforceConnID, connID, "delete_failed", "", "", "", payload.ID, false, "blocked", err.Error(), nil)
+				http.Error(w, jsonError(err.Error()), http.StatusForbidden)
+				return
+			}
+			if err := deleteLaravelFailedJob(r, db, driver, payload.ID); err != nil {
+				writeLaravelQueueAudit(r, enforceConnID, connID, "delete_failed", "", "", "", payload.ID, false, "failed", err.Error(), nil)
+				http.Error(w, jsonError(err.Error()), http.StatusBadGateway)
+				return
+			}
+			writeLaravelQueueAudit(r, enforceConnID, connID, "delete_failed", "", "", "", payload.ID, false, "success", "", nil)
+			json.NewEncoder(w).Encode(map[string]string{"message": "Failed job deleted"})
+		default:
+			http.Error(w, `{"error":"unsupported failed job action"}`, http.StatusBadRequest)
+		}
+	}
+}
+
+func LaravelQueueHorizon() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		client, _, err := openRedisClient(connID, redisDBFromRequest(r))
+		if err != nil {
+			http.Error(w, jsonError(err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		keys, err := scanRedisKeys(r.Context(), client, "horizon:*", 500)
+		if err != nil {
+			http.Error(w, jsonError("horizon scan failed: "+err.Error()), http.StatusBadGateway)
+			return
+		}
+		summary := laravelHorizonSummary{
+			Detected:   len(keys) > 0,
+			KeyCount:   len(keys),
+			Workload:   map[string]int64{},
+			SampleKeys: keys,
+		}
+		if len(summary.SampleKeys) > 12 {
+			summary.SampleKeys = summary.SampleKeys[:12]
+		}
+		summary.Supervisors, _ = redisInt(client.command(r.Context(), "SCARD", "horizon:supervisors"))
+		summary.Masters, _ = redisInt(client.command(r.Context(), "SCARD", "horizon:masters"))
+		summary.RecentJobs, _ = redisInt(client.command(r.Context(), "ZCARD", "horizon:recent_jobs"))
+		summary.FailedJobs, _ = redisInt(client.command(r.Context(), "ZCARD", "horizon:failed_jobs"))
+
+		workloadRaw, err := client.command(r.Context(), "HGETALL", "horizon:workload")
+		if err == nil {
+			for queue, value := range stringPairsToMap(workloadRaw) {
+				n, _ := strconv.ParseInt(value, 10, 64)
+				summary.Workload[queue] = n
+			}
+		}
+		json.NewEncoder(w).Encode(summary)
+	}
+}
+
+func deleteLaravelFailedJob(r *http.Request, db *sql.DB, _ string, id int64) error {
+	if _, err := db.ExecContext(r.Context(), "DELETE FROM failed_jobs WHERE id = ?", id); err != nil {
+		return fmt.Errorf("failed job delete failed: %w", err)
+	}
+	return nil
+}
+
+func laravelQueueRemoveJob(r *http.Request, client *redisClient, payload laravelQueueActionRequest) error {
+	if payload.Raw == "" {
+		return fmt.Errorf("job payload is required")
+	}
+	switch payload.State {
+	case "ready":
+		_, err := client.command(r.Context(), "LREM", laravelQueueKey(payload.Prefix, payload.Queue, ""), "0", payload.Raw)
+		if err != nil {
+			return fmt.Errorf("redis lrem failed: %w", err)
+		}
+	case "delayed", "reserved":
+		_, err := client.command(r.Context(), "ZREM", laravelQueueKey(payload.Prefix, payload.Queue, payload.State), payload.Raw)
+		if err != nil {
+			return fmt.Errorf("redis zrem failed: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported job state")
+	}
+	return nil
+}
+
+func laravelQueuePrefix(r *http.Request) string {
+	prefix := strings.Trim(strings.TrimSpace(r.URL.Query().Get("prefix")), ":")
+	if prefix == "" {
+		return "queues"
+	}
+	return prefix
+}
+
+func laravelQueueNameFromKey(prefix, key string) string {
+	base := prefix + ":"
+	if !strings.HasPrefix(key, base) {
+		return ""
+	}
+	name := strings.TrimPrefix(key, base)
+	for _, suffix := range []string{":delayed", ":reserved", ":notify"} {
+		name = strings.TrimSuffix(name, suffix)
+	}
+	if name == "" || strings.Contains(name, ":") {
+		return ""
+	}
+	return name
+}
+
+func laravelQueueKey(prefix, queue, suffix string) string {
+	key := prefix + ":" + queue
+	if suffix != "" {
+		key += ":" + suffix
+	}
+	return key
+}
+
+func parseLaravelQueueJob(raw, queue, state string, score int64) laravelQueueJob {
+	sum := sha1.Sum([]byte(raw))
+	job := laravelQueueJob{
+		ID:    hex.EncodeToString(sum[:8]),
+		State: state,
+		Queue: queue,
+		Score: score,
+		Raw:   raw,
+	}
+	if score > 0 {
+		job.AvailableAt = time.Unix(score, 0).Format(time.RFC3339)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return job
+	}
+	job.Payload = payload
+	job.UUID, _ = payload["uuid"].(string)
+	job.DisplayName, _ = payload["displayName"].(string)
+	job.Job, _ = payload["job"].(string)
+	if attempts, ok := payload["attempts"].(float64); ok {
+		job.Attempts = int64(attempts)
+	}
+	job.MaxTries = laravelPayloadInt(payload["maxTries"])
+	job.Timeout = laravelPayloadInt(payload["timeout"])
+	job.Backoff = payload["backoff"]
+	if data, ok := payload["data"].(map[string]any); ok {
+		job.CommandName, _ = data["commandName"].(string)
+	}
+	if job.ID == "" && job.UUID != "" {
+		job.ID = job.UUID
+	}
+	if job.DisplayName == "" && job.CommandName != "" {
+		job.DisplayName = job.CommandName
+	}
+	if job.DisplayName == "" {
+		job.DisplayName = fmt.Sprintf("%s job", state)
+	}
+	return job
+}
+
+func laravelPayloadInt(value any) int64 {
+	switch v := value.(type) {
+	case float64:
+		return int64(v)
+	case int64:
+		return v
+	case string:
+		n, _ := strconv.ParseInt(v, 10, 64)
+		return n
+	default:
+		return 0
+	}
+}

--- a/server/handlers/laravel_queue_ops.go
+++ b/server/handlers/laravel_queue_ops.go
@@ -1,0 +1,475 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	appdb "github.com/anveesa/nias/db"
+)
+
+type laravelQueueFeatureFlags struct {
+	Retry          bool `json:"retry"`
+	Delete         bool `json:"delete"`
+	Clear          bool `json:"clear"`
+	EditedReplay   bool `json:"editedReplay"`
+	ReadOnly       bool `json:"readOnly"`
+	RequireConfirm bool `json:"requireConfirm"`
+}
+
+type laravelQueueRules struct {
+	ReadyMax         int64 `json:"readyMax"`
+	FailedMax        int64 `json:"failedMax"`
+	StuckMax         int64 `json:"stuckMax"`
+	OldestMinutesMax int64 `json:"oldestMinutesMax"`
+	NoConsumption    bool  `json:"noConsumption"`
+}
+
+type laravelQueueOpsSettings struct {
+	FeatureFlags        laravelQueueFeatureFlags `json:"featureFlags"`
+	QueueRules          laravelQueueRules        `json:"queueRules"`
+	BusinessFieldsInput string                   `json:"businessFieldsInput"`
+	SandboxQueue        string                   `json:"sandboxQueue"`
+	Environment         string                   `json:"environment"`
+	UpdatedAt           string                   `json:"updated_at,omitempty"`
+	UpdatedBy           int64                    `json:"updated_by,omitempty"`
+}
+
+type laravelQueueAuditRow struct {
+	ID            int64          `json:"id"`
+	ConnID        int64          `json:"conn_id"`
+	FailedConnID  int64          `json:"failed_conn_id"`
+	UserID        int64          `json:"user_id"`
+	Username      string         `json:"username"`
+	Action        string         `json:"action"`
+	Queue         string         `json:"queue"`
+	TargetQueue   string         `json:"target_queue"`
+	JobUUID       string         `json:"job_uuid"`
+	FailedJobID   int64          `json:"failed_job_id"`
+	PayloadEdited bool           `json:"payload_edited"`
+	Status        string         `json:"status"`
+	Error         string         `json:"error"`
+	Details       map[string]any `json:"details"`
+	CreatedAt     string         `json:"created_at"`
+}
+
+type laravelQueueQuarantineRow struct {
+	ID           int64  `json:"id"`
+	ConnID       int64  `json:"conn_id"`
+	FailedConnID int64  `json:"failed_conn_id"`
+	FailedJobID  int64  `json:"failed_job_id"`
+	UUID         string `json:"uuid"`
+	Queue        string `json:"queue"`
+	JobName      string `json:"job_name"`
+	Payload      string `json:"payload"`
+	Exception    string `json:"exception"`
+	Reason       string `json:"reason"`
+	Status       string `json:"status"`
+	CreatedBy    int64  `json:"created_by"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+}
+
+type laravelQueueQuarantineRequest struct {
+	FailedConnID int64  `json:"failed_conn_id"`
+	FailedJobID  int64  `json:"failed_job_id"`
+	UUID         string `json:"uuid"`
+	Queue        string `json:"queue"`
+	JobName      string `json:"job_name"`
+	Payload      string `json:"payload"`
+	Exception    string `json:"exception"`
+	Reason       string `json:"reason"`
+}
+
+type laravelQueueAlertRequest struct {
+	Alerts []struct {
+		Level  string `json:"level"`
+		Title  string `json:"title"`
+		Detail string `json:"detail"`
+	} `json:"alerts"`
+	Queue  string `json:"queue"`
+	Prefix string `json:"prefix"`
+}
+
+type laravelQueueAgentRequest struct {
+	Command string         `json:"command"`
+	Queue   string         `json:"queue"`
+	Options map[string]any `json:"options"`
+}
+
+func LaravelQueueOpsSettings() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			settings, err := getLaravelQueueOpsSettings(connID)
+			if err != nil {
+				http.Error(w, jsonError("failed to load queue settings"), http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(settings)
+		case http.MethodPut:
+			var settings laravelQueueOpsSettings
+			if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
+				http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+				return
+			}
+			settings = normalizeLaravelQueueOpsSettings(settings)
+			userID, _, _ := currentUserFromHeaders(r)
+			if err := saveLaravelQueueOpsSettings(connID, userID, settings); err != nil {
+				http.Error(w, jsonError("failed to save queue settings"), http.StatusInternalServerError)
+				return
+			}
+			writeLaravelQueueAudit(r, connID, 0, "settings_update", "", "", "", 0, false, "success", "", map[string]any{"environment": settings.Environment})
+			json.NewEncoder(w).Encode(settings)
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func LaravelQueueAudit() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		limit := queryInt(r, "limit", 100, 1, 500)
+		rows, err := appdb.DB.Query(appdb.ConvertQuery(`
+			SELECT id, conn_id, failed_conn_id, user_id, username, action, queue, target_queue, job_uuid, failed_job_id,
+			       payload_edited, status, error, details_json, created_at
+			FROM laravel_queue_audit
+			WHERE conn_id = ?
+			ORDER BY id DESC
+			LIMIT ?
+		`), connID, limit)
+		if err != nil {
+			http.Error(w, jsonError("failed to load queue audit"), http.StatusInternalServerError)
+			return
+		}
+		defer rows.Close()
+		items := []laravelQueueAuditRow{}
+		for rows.Next() {
+			var item laravelQueueAuditRow
+			var edited int
+			var details string
+			if err := rows.Scan(&item.ID, &item.ConnID, &item.FailedConnID, &item.UserID, &item.Username, &item.Action, &item.Queue, &item.TargetQueue, &item.JobUUID, &item.FailedJobID, &edited, &item.Status, &item.Error, &details, &item.CreatedAt); err != nil {
+				http.Error(w, jsonError("failed to read queue audit"), http.StatusInternalServerError)
+				return
+			}
+			item.PayloadEdited = edited == 1
+			item.Details = parseJSONMapSafe(details)
+			items = append(items, item)
+		}
+		json.NewEncoder(w).Encode(items)
+	}
+}
+
+func LaravelQueueQuarantine() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			items, err := listLaravelQueueQuarantine(connID)
+			if err != nil {
+				http.Error(w, jsonError("failed to load quarantine"), http.StatusInternalServerError)
+				return
+			}
+			json.NewEncoder(w).Encode(items)
+		case http.MethodPost:
+			var body laravelQueueQuarantineRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+				return
+			}
+			if body.FailedJobID <= 0 {
+				http.Error(w, `{"error":"failed job id is required"}`, http.StatusBadRequest)
+				return
+			}
+			userID, _, _ := currentUserFromHeaders(r)
+			now := time.Now().UTC().Format("2006-01-02 15:04:05")
+			_, err := appdb.DB.Exec(appdb.ConvertQuery(`
+				INSERT INTO laravel_queue_quarantine
+					(conn_id, failed_conn_id, failed_job_id, uuid, queue, job_name, payload, exception, reason, status, created_by, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'quarantined', ?, ?, ?)
+				ON CONFLICT(conn_id, failed_conn_id, failed_job_id)
+				DO UPDATE SET uuid = excluded.uuid, queue = excluded.queue, job_name = excluded.job_name, payload = excluded.payload,
+					exception = excluded.exception, reason = excluded.reason, status = 'quarantined', updated_at = excluded.updated_at
+			`), connID, body.FailedConnID, body.FailedJobID, body.UUID, body.Queue, body.JobName, body.Payload, body.Exception, body.Reason, userID, now, now)
+			if err != nil {
+				// MySQL fallback for ON CONFLICT.
+				_, err = appdb.DB.Exec(appdb.ConvertQuery(`
+					INSERT INTO laravel_queue_quarantine
+						(conn_id, failed_conn_id, failed_job_id, uuid, queue, job_name, payload, exception, reason, status, created_by, created_at, updated_at)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'quarantined', ?, ?, ?)
+				`), connID, body.FailedConnID, body.FailedJobID, body.UUID, body.Queue, body.JobName, body.Payload, body.Exception, body.Reason, userID, now, now)
+			}
+			if err != nil {
+				http.Error(w, jsonError("failed to quarantine job"), http.StatusInternalServerError)
+				return
+			}
+			writeLaravelQueueAudit(r, connID, body.FailedConnID, "quarantine", body.Queue, "", body.UUID, body.FailedJobID, false, "success", "", map[string]any{"reason": body.Reason})
+			json.NewEncoder(w).Encode(map[string]string{"message": "Job quarantined"})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func LaravelQueueQuarantineItem() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		id, err := strconv.ParseInt(strings.TrimPrefix(r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:], ""), 10, 64)
+		if err != nil || id <= 0 {
+			http.Error(w, `{"error":"invalid quarantine id"}`, http.StatusBadRequest)
+			return
+		}
+		if r.Method != http.MethodDelete {
+			http.NotFound(w, r)
+			return
+		}
+		_, err = appdb.DB.Exec(appdb.ConvertQuery(`UPDATE laravel_queue_quarantine SET status = 'released', updated_at = ? WHERE id = ? AND conn_id = ?`), time.Now().UTC().Format("2006-01-02 15:04:05"), id, connID)
+		if err != nil {
+			http.Error(w, jsonError("failed to release quarantine item"), http.StatusInternalServerError)
+			return
+		}
+		writeLaravelQueueAudit(r, connID, 0, "quarantine_release", "", "", "", id, false, "success", "", nil)
+		json.NewEncoder(w).Encode(map[string]string{"message": "Quarantine item released"})
+	}
+}
+
+func LaravelQueueAlerts() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		var body laravelQueueAlertRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+			return
+		}
+		userID, _, _ := currentUserFromHeaders(r)
+		count := 0
+		for _, alert := range body.Alerts {
+			title := strings.TrimSpace(alert.Title)
+			detail := strings.TrimSpace(alert.Detail)
+			if title == "" || detail == "" {
+				continue
+			}
+			EmitNotification(NotificationEventInput{
+				EventType:    "laravel_queue.alert",
+				Category:     "queue",
+				Severity:     alert.Level,
+				Title:        title,
+				Message:      detail,
+				EntityType:   "laravel_queue",
+				ConnectionID: connID,
+				ActorUserID:  userID,
+				Payload: map[string]any{
+					"queue":  body.Queue,
+					"prefix": body.Prefix,
+					"detail": detail,
+				},
+			})
+			count++
+		}
+		writeLaravelQueueAudit(r, connID, 0, "alerts_emit", body.Queue, "", "", 0, false, "success", "", map[string]any{"count": count})
+		json.NewEncoder(w).Encode(map[string]any{"message": "alerts emitted", "count": count})
+	}
+}
+
+func LaravelQueueAgentAction() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		connID, err := connectionIDFromPath(r.URL.Path)
+		if err != nil {
+			http.Error(w, `{"error":"invalid connection id"}`, http.StatusBadRequest)
+			return
+		}
+		var body laravelQueueAgentRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		writeLaravelQueueAudit(r, connID, 0, "agent_"+strings.TrimSpace(body.Command), body.Queue, "", "", 0, false, "blocked", "laravel agent is not configured", body.Options)
+		http.Error(w, jsonError("Laravel agent is not configured yet. Install a Laravel-side agent/API before running queue worker commands."), http.StatusNotImplemented)
+	}
+}
+
+func getLaravelQueueOpsSettings(connID int64) (laravelQueueOpsSettings, error) {
+	settings := defaultLaravelQueueOpsSettings()
+	var raw, updatedAt sql.NullString
+	var updatedBy sql.NullInt64
+	err := appdb.DB.QueryRow(appdb.ConvertQuery(`
+		SELECT settings_json, updated_at, updated_by
+		FROM laravel_queue_profiles
+		WHERE conn_id = ? AND environment = 'default'
+	`), connID).Scan(&raw, &updatedAt, &updatedBy)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return settings, nil
+		}
+		return settings, err
+	}
+	if raw.Valid {
+		_ = json.Unmarshal([]byte(raw.String), &settings)
+	}
+	settings = normalizeLaravelQueueOpsSettings(settings)
+	settings.UpdatedAt = updatedAt.String
+	settings.UpdatedBy = updatedBy.Int64
+	return settings, nil
+}
+
+func saveLaravelQueueOpsSettings(connID, userID int64, settings laravelQueueOpsSettings) error {
+	settings.Environment = "default"
+	raw, _ := json.Marshal(settings)
+	now := time.Now().UTC().Format("2006-01-02 15:04:05")
+
+	// Try UPSERT (SQLite / PostgreSQL ON CONFLICT syntax)
+	_, err := appdb.DB.Exec(appdb.ConvertQuery(`
+		INSERT INTO laravel_queue_profiles
+			(conn_id, environment, settings_json, created_by, updated_by, created_at, updated_at)
+		VALUES (?, 'default', ?, ?, ?, ?, ?)
+		ON CONFLICT(conn_id, environment)
+		DO UPDATE SET settings_json = excluded.settings_json, updated_by = excluded.updated_by, updated_at = excluded.updated_at
+	`), connID, string(raw), userID, userID, now, now)
+	if err == nil {
+		return nil
+	}
+
+	// MySQL fallback: INSERT ... ON DUPLICATE KEY UPDATE
+	_, err = appdb.DB.Exec(`
+		INSERT INTO laravel_queue_profiles
+			(conn_id, environment, settings_json, created_by, updated_by, created_at, updated_at)
+		VALUES (?, 'default', ?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE settings_json = VALUES(settings_json), updated_by = VALUES(updated_by), updated_at = VALUES(updated_at)
+	`, connID, string(raw), userID, userID, now, now)
+	return err
+}
+
+func defaultLaravelQueueOpsSettings() laravelQueueOpsSettings {
+	return laravelQueueOpsSettings{
+		Environment: "default",
+		FeatureFlags: laravelQueueFeatureFlags{
+			Retry:          true,
+			Delete:         true,
+			Clear:          true,
+			EditedReplay:   true,
+			ReadOnly:       false,
+			RequireConfirm: true,
+		},
+		QueueRules: laravelQueueRules{
+			ReadyMax:         100,
+			FailedMax:        10,
+			StuckMax:         0,
+			OldestMinutesMax: 30,
+			NoConsumption:    true,
+		},
+		BusinessFieldsInput: "tenant_id,user_id,order_id,invoice_id,email,amount",
+		SandboxQueue:        "debug",
+	}
+}
+
+func normalizeLaravelQueueOpsSettings(settings laravelQueueOpsSettings) laravelQueueOpsSettings {
+	def := defaultLaravelQueueOpsSettings()
+	if settings.Environment == "" {
+		settings.Environment = "default"
+	}
+	if settings.BusinessFieldsInput == "" {
+		settings.BusinessFieldsInput = def.BusinessFieldsInput
+	}
+	if settings.SandboxQueue == "" {
+		settings.SandboxQueue = def.SandboxQueue
+	}
+	return settings
+}
+
+func enforceLaravelQueueAction(connID int64, action string) error {
+	settings, err := getLaravelQueueOpsSettings(connID)
+	if err != nil {
+		return nil
+	}
+	flags := settings.FeatureFlags
+	if flags.ReadOnly {
+		return fmt.Errorf("read-only mode is enabled")
+	}
+	switch action {
+	case "retry":
+		if !flags.Retry {
+			return fmt.Errorf("retry actions are disabled")
+		}
+	case "delete":
+		if !flags.Delete {
+			return fmt.Errorf("delete actions are disabled")
+		}
+	case "clear":
+		if !flags.Clear {
+			return fmt.Errorf("clear queue is disabled")
+		}
+	case "editedReplay":
+		if !flags.EditedReplay {
+			return fmt.Errorf("edited payload replay is disabled")
+		}
+	}
+	return nil
+}
+
+func listLaravelQueueQuarantine(connID int64) ([]laravelQueueQuarantineRow, error) {
+	rows, err := appdb.DB.Query(appdb.ConvertQuery(`
+		SELECT id, conn_id, failed_conn_id, failed_job_id, uuid, queue, job_name, payload, exception, reason, status, created_by, created_at, updated_at
+		FROM laravel_queue_quarantine
+		WHERE conn_id = ? AND status = 'quarantined'
+		ORDER BY id DESC
+	`), connID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []laravelQueueQuarantineRow{}
+	for rows.Next() {
+		var item laravelQueueQuarantineRow
+		if err := rows.Scan(&item.ID, &item.ConnID, &item.FailedConnID, &item.FailedJobID, &item.UUID, &item.Queue, &item.JobName, &item.Payload, &item.Exception, &item.Reason, &item.Status, &item.CreatedBy, &item.CreatedAt, &item.UpdatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+func writeLaravelQueueAudit(r *http.Request, connID, failedConnID int64, action, queue, targetQueue, jobUUID string, failedJobID int64, payloadEdited bool, status, actionErr string, details map[string]any) {
+	userID, username, _ := currentUserFromHeaders(r)
+	if details == nil {
+		details = map[string]any{}
+	}
+	raw, _ := json.Marshal(details)
+	edited := 0
+	if payloadEdited {
+		edited = 1
+	}
+	_, _ = appdb.DB.Exec(appdb.ConvertQuery(`
+		INSERT INTO laravel_queue_audit
+			(conn_id, failed_conn_id, user_id, username, action, queue, target_queue, job_uuid, failed_job_id, payload_edited, status, error, details_json, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`), connID, failedConnID, userID, username, action, queue, targetQueue, jobUUID, failedJobID, edited, status, actionErr, string(raw), time.Now().UTC().Format("2006-01-02 15:04:05"))
+}

--- a/server/handlers/notifications.go
+++ b/server/handlers/notifications.go
@@ -699,6 +699,14 @@ func queueNotificationDeliveries(eventID int64, eventType, severity string, conn
 	}
 }
 
+type pendingDelivery struct {
+	deliveryID      int64
+	payloadJSON     string
+	eventPayloadJSON string
+	event           NotificationEvent
+	target          notificationTargetRow
+}
+
 func processPendingNotificationDeliveries() {
 	rows, err := appdb.DB.Query(appdb.ConvertQuery(`
 		SELECT d.id, d.event_id, d.target_id, d.payload_json,
@@ -716,25 +724,27 @@ func processPendingNotificationDeliveries() {
 	if err != nil {
 		return
 	}
-	defer rows.Close()
 
+	// Scan all rows first and close the cursor before making any network calls.
+	var pending []pendingDelivery
 	for rows.Next() {
-		var deliveryID int64
-		var payloadJSON, eventPayloadJSON string
-		var event NotificationEvent
-		var target notificationTargetRow
+		var d pendingDelivery
 		var active int
 		if err := rows.Scan(
-			&deliveryID, &event.ID, &target.ID, &payloadJSON,
-			&event.EventType, &event.Category, &event.Severity, &event.Title, &event.Message, &event.EntityType, &event.EntityID, &event.ConnectionID, &event.ActorUserID, &eventPayloadJSON, &event.CreatedAt,
-			&target.Name, &target.Type, &target.Description, &target.ConfigJSON, &target.SecretEnc, &active, &target.CreatedBy, &target.CreatedAt, &target.UpdatedAt,
+			&d.deliveryID, &d.event.ID, &d.target.ID, &d.payloadJSON,
+			&d.event.EventType, &d.event.Category, &d.event.Severity, &d.event.Title, &d.event.Message, &d.event.EntityType, &d.event.EntityID, &d.event.ConnectionID, &d.event.ActorUserID, &d.eventPayloadJSON, &d.event.CreatedAt,
+			&d.target.Name, &d.target.Type, &d.target.Description, &d.target.ConfigJSON, &d.target.SecretEnc, &active, &d.target.CreatedBy, &d.target.CreatedAt, &d.target.UpdatedAt,
 		); err != nil {
 			continue
 		}
-		target.IsActive = active == 1
-		event.Payload = parseJSONMapSafe(eventPayloadJSON)
+		d.target.IsActive = active == 1
+		d.event.Payload = parseJSONMapSafe(d.eventPayloadJSON)
+		pending = append(pending, d)
+	}
+	rows.Close()
 
-		lockKey := fmt.Sprintf("notification:delivery:%d", deliveryID)
+	for _, d := range pending {
+		lockKey := fmt.Sprintf("notification:delivery:%d", d.deliveryID)
 		lockOwner := fmt.Sprintf("%s:%d", notificationInstanceID, time.Now().UTC().UnixNano())
 		lockCtx, lockCancel := context.WithTimeout(context.Background(), 2*time.Second)
 		locked, lockErr := cache.Default().AcquireLock(lockCtx, lockKey, lockOwner, 2*time.Minute)
@@ -748,11 +758,11 @@ func processPendingNotificationDeliveries() {
 			UPDATE notification_deliveries
 			SET status = 'sending', attempts = attempts + 1, last_attempt_at = ?, updated_at = ?
 			WHERE id = ?
-		`), lastAttempt, lastAttempt, deliveryID)
+		`), lastAttempt, lastAttempt, d.deliveryID)
 
-		statusCode, sendErr := sendNotificationToTarget(target, event, []byte(payloadJSON))
+		statusCode, sendErr := sendNotificationToTarget(d.target, d.event, []byte(d.payloadJSON))
 		if sendErr != nil {
-			attempts := currentDeliveryAttempts(deliveryID)
+			attempts := currentDeliveryAttempts(d.deliveryID)
 			nextAttemptAt := nextNotificationAttempt(attempts)
 			status := "retrying"
 			if attempts >= 5 {
@@ -763,7 +773,7 @@ func processPendingNotificationDeliveries() {
 				UPDATE notification_deliveries
 				SET status = ?, last_error = ?, last_response_code = ?, next_attempt_at = ?, updated_at = ?
 				WHERE id = ?
-			`), status, truncateNotificationError(sendErr.Error()), statusCode, nextAttemptAt, lastAttempt, deliveryID)
+			`), status, truncateNotificationError(sendErr.Error()), statusCode, nextAttemptAt, lastAttempt, d.deliveryID)
 			releaseNotificationDeliveryLock(lockKey, lockOwner)
 			continue
 		}
@@ -771,7 +781,7 @@ func processPendingNotificationDeliveries() {
 			UPDATE notification_deliveries
 			SET status = 'delivered', last_error = '', last_response_code = ?, next_attempt_at = ?, updated_at = ?
 			WHERE id = ?
-		`), statusCode, lastAttempt, lastAttempt, deliveryID)
+		`), statusCode, lastAttempt, lastAttempt, d.deliveryID)
 		releaseNotificationDeliveryLock(lockKey, lockOwner)
 	}
 }
@@ -1320,7 +1330,7 @@ func parsePathActionID(path, prefix, suffix string) (int64, error) {
 }
 
 func insertRowReturningID(query string, args ...any) (int64, error) {
-	if appdb.IsPostgreSQL() || appdb.IsMySQL() {
+	if appdb.IsPostgreSQL() {
 		query = strings.TrimSpace(query)
 		if !strings.Contains(strings.ToUpper(query), "RETURNING ID") {
 			query += " RETURNING id"
@@ -1331,6 +1341,7 @@ func insertRowReturningID(query string, args ...any) (int64, error) {
 		}
 		return id, nil
 	}
+	// MySQL and SQLite both use LastInsertId()
 	res, err := appdb.DB.Exec(query, args...)
 	if err != nil {
 		return 0, err

--- a/server/handlers/pool.go
+++ b/server/handlers/pool.go
@@ -38,13 +38,21 @@ func GetDB(connID int64) (*sql.DB, string, error) {
 
 	if ok {
 		if err := entry.db.Ping(); err == nil {
-			entry.lastUsed = time.Now()
+			// Update lastUsed under write lock to avoid the data race.
+			dbPool.Lock()
+			if e, still := dbPool.entries[connID]; still {
+				e.lastUsed = time.Now()
+			}
+			dbPool.Unlock()
 			return entry.db, entry.driver, nil
 		}
-		// Stale — close and re-open
+		// Ping failed — evict under write lock. Re-check the entry is still
+		// the same one we tested to avoid a TOCTOU double-close.
 		dbPool.Lock()
-		entry.db.Close()
-		delete(dbPool.entries, connID)
+		if current, still := dbPool.entries[connID]; still && current == entry {
+			entry.db.Close()
+			delete(dbPool.entries, connID)
+		}
 		dbPool.Unlock()
 	}
 

--- a/server/main.go
+++ b/server/main.go
@@ -74,8 +74,10 @@ func main() {
 	handlers.SetEncryptionKey(cfg.EncryptionKey)
 
 	// Start automatic backup if enabled
+	backupCtx, backupCancel := context.WithCancel(context.Background())
+	defer backupCancel()
 	if cfg.BackupEnabled {
-		go startAutoBackup(cfg)
+		go startAutoBackup(backupCtx, cfg)
 	}
 	handlers.StartNotificationWorker()
 
@@ -314,6 +316,30 @@ func registerRoutes(mux *http.ServeMux, cfg *config.Config) {
 				requireAny(handlers.PermConnectionsView, handlers.PermSchemaBrowse)(handlers.RedisGenerateScript())(w, r)
 			case sub == "redis" && len(parts) >= 3 && parts[2] == "script" && r.Method == http.MethodPost:
 				requireAny(handlers.PermConnectionsEdit, handlers.PermSchemaBrowse)(handlers.RedisExecuteScript())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 3 && parts[2] == "queues" && r.Method == http.MethodGet:
+				requireAny(handlers.PermConnectionsView, handlers.PermSchemaBrowse)(handlers.LaravelQueueQueues())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 3 && parts[2] == "jobs" && r.Method == http.MethodGet:
+				requireAny(handlers.PermConnectionsView, handlers.PermSchemaBrowse)(handlers.LaravelQueueJobs())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 3 && parts[2] == "failed-jobs" && r.Method == http.MethodGet:
+				requireAny(handlers.PermConnectionsView, handlers.PermSchemaBrowse)(handlers.LaravelQueueFailedJobs())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 3 && parts[2] == "horizon" && r.Method == http.MethodGet:
+				requireAny(handlers.PermConnectionsView, handlers.PermSchemaBrowse)(handlers.LaravelQueueHorizon())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 3 && parts[2] == "ops-settings" && (r.Method == http.MethodGet || r.Method == http.MethodPut):
+				requireAny(handlers.PermConnectionsView, handlers.PermSchemaBrowse)(handlers.LaravelQueueOpsSettings())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 3 && parts[2] == "audit" && r.Method == http.MethodGet:
+				requireAny(handlers.PermAuditView, handlers.PermConnectionsView)(handlers.LaravelQueueAudit())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 3 && parts[2] == "quarantine" && (r.Method == http.MethodGet || r.Method == http.MethodPost):
+				requireAny(handlers.PermConnectionsView, handlers.PermSchemaBrowse)(handlers.LaravelQueueQuarantine())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 4 && parts[2] == "quarantine" && r.Method == http.MethodDelete:
+				requireAny(handlers.PermConnectionsEdit, handlers.PermSchemaBrowse)(handlers.LaravelQueueQuarantineItem())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 3 && parts[2] == "alerts" && r.Method == http.MethodPost:
+				requireAny(handlers.PermConnectionsView, handlers.PermSchemaBrowse)(handlers.LaravelQueueAlerts())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 3 && parts[2] == "agent" && r.Method == http.MethodPost:
+				requireAny(handlers.PermConnectionsEdit, handlers.PermSchemaBrowse)(handlers.LaravelQueueAgentAction())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 4 && (parts[3] == "retry-failed" || parts[3] == "delete-failed") && r.Method == http.MethodPost:
+				requireAny(handlers.PermConnectionsEdit, handlers.PermSchemaBrowse)(handlers.LaravelQueueFailedJobAction())(w, r)
+			case sub == "laravel-queue" && len(parts) >= 4 && r.Method == http.MethodPost:
+				requireAny(handlers.PermConnectionsEdit, handlers.PermSchemaBrowse)(handlers.LaravelQueueAction())(w, r)
 			case sub == "backup" && r.Method == http.MethodGet:
 				requireAny(handlers.PermBackupsManage)(handlers.GetBackup())(w, r)
 			case sub == "restore" && r.Method == http.MethodPost:
@@ -1032,16 +1058,24 @@ func registerStaticRoutes(mux *http.ServeMux) {
 }
 
 // Auto backup
-func startAutoBackup(cfg *config.Config) {
+func startAutoBackup(ctx context.Context, cfg *config.Config) {
 	ticker := time.NewTicker(time.Duration(cfg.BackupHours) * time.Hour)
 	defer ticker.Stop()
 
-	// Run initial backup after 1 minute
-	time.Sleep(time.Minute)
-	runBackup(cfg)
-
-	for range ticker.C {
+	select {
+	case <-time.After(time.Minute):
 		runBackup(cfg)
+	case <-ctx.Done():
+		return
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			runBackup(cfg)
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/web/src/components/database/DataSessionPane.vue
+++ b/web/src/components/database/DataSessionPane.vue
@@ -30,6 +30,7 @@ const router = useRouter()
 const activeConn = computed(() =>
   props.connId ? connections.value.find(c => c.id === props.connId) ?? null : null
 )
+const supportsRelationalSchema = computed(() => !!activeConn.value && activeConn.value.driver !== 'redis')
 
 // ── Data browser state ────────────────────────────────────────────
 const selected = ref<{ db: string; table: string } | null>(null)
@@ -193,7 +194,7 @@ watch(() => props.connId, async (id) => {
   objectDetail.value = null
   selectedObjectKey.value = ''
   activeDatabase.value = ''
-  if (!id) return
+  if (!id || !supportsRelationalSchema.value) return
   await fetchSchemaList(id)
   activeDatabase.value = databases.value[0]?.name ?? ''
 }, { immediate: true })
@@ -475,6 +476,10 @@ function driverLabel(d: string) { return ({ postgres: 'PG', mysql: 'MY', mariadb
     </div>
 
     <!-- DATA BROWSER -->
+    <div v-else-if="!supportsRelationalSchema" v-show="activeSubTab === 'data' || activeSubTab === 'schema' || activeSubTab === 'explorer'" class="empty-state" style="flex:1">
+      Redis does not expose relational schema here. Use the Redis or Laravel Queue page for this connection.
+    </div>
+
     <div v-else v-show="activeSubTab === 'data'" style="display:flex;flex:1;min-height:0;overflow:hidden">
       <div class="sidebar-panel">
         <div class="panel-header">
@@ -519,7 +524,7 @@ function driverLabel(d: string) { return ({ postgres: 'PG', mysql: 'MY', mariadb
     </div>
 
     <!-- SCHEMA -->
-    <div v-if="activeConn" v-show="activeSubTab === 'schema'" style="display:flex;flex:1;min-height:0;overflow:hidden">
+    <div v-if="activeConn && supportsRelationalSchema" v-show="activeSubTab === 'schema'" style="display:flex;flex:1;min-height:0;overflow:hidden">
       <div class="sidebar-panel">
         <div class="panel-header">
           <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap">{{ activeConn.name }}</span>
@@ -560,7 +565,7 @@ function driverLabel(d: string) { return ({ postgres: 'PG', mysql: 'MY', mariadb
     </div>
 
     <!-- EXPLORER (Full Schema Metadata) -->
-    <div v-if="activeConn" v-show="activeSubTab === 'explorer'" class="explorer-view">
+    <div v-if="activeConn && supportsRelationalSchema" v-show="activeSubTab === 'explorer'" class="explorer-view">
       <div class="explorer-sidebar">
         <div class="explorer-sidebar__head">
           <select v-model="activeDatabase" class="explorer-db-select" :disabled="!databases.length">

--- a/web/src/components/layout/AppSidebar.vue
+++ b/web/src/components/layout/AppSidebar.vue
@@ -68,7 +68,7 @@ const driverLabel: Record<string, string> = { postgres: 'PG', mysql: 'MY', maria
 
 function selectConn(conn: Connection) {
   emit('select-conn', conn.id)
-  const stayViews = ['schema', 'data', 'er', 'dashboard', 'query', 'redis']
+  const stayViews = ['schema', 'data', 'er', 'dashboard', 'query', 'redis', 'laravel-queue']
   const current = router.currentRoute.value.name as string
   if (conn.driver === 'redis' && current !== 'redis') router.push({ name: 'redis' })
   else if (conn.driver !== 'redis' && (current === 'redis' || !stayViews.includes(current))) router.push({ name: 'query' })

--- a/web/src/components/layout/ConnectionsDropdown.vue
+++ b/web/src/components/layout/ConnectionsDropdown.vue
@@ -80,7 +80,7 @@ function toggleFolder(id: number) {
 function selectConn(conn: Connection) {
   emit('select-conn', conn.id)
   emit('close')
-  const stayViews = ['data', 'er', 'dashboard', 'redis']
+  const stayViews = ['data', 'er', 'dashboard', 'redis', 'laravel-queue']
   const current = router.currentRoute.value.name as string
   if (conn.driver === 'redis' && current !== 'redis') router.push({ name: 'redis' })
   else if (conn.driver !== 'redis' && (current === 'redis' || !stayViews.includes(current))) router.push({ name: 'data' })

--- a/web/src/components/layout/TopNav.vue
+++ b/web/src/components/layout/TopNav.vue
@@ -113,6 +113,14 @@ const allMenuGroups: MenuGroup[] = [
     ],
   },
   {
+    id: 'messaging',
+    label: 'Messaging',
+    icon: 'activity',
+    items: [
+      { name: 'laravel-queue', label: 'Laravel Queue', desc: 'Inspect Redis-backed Laravel queue jobs, delayed jobs, and reserved jobs', icon: 'activity', permissionsAny: ['connections.view', 'schema.browse'] },
+    ],
+  },
+  {
     id: 'operate',
     label: 'Operations',
     icon: 'activity',

--- a/web/src/composables/useLaravelQueue.ts
+++ b/web/src/composables/useLaravelQueue.ts
@@ -1,0 +1,217 @@
+import axios from 'axios'
+
+export interface LaravelQueueSummary {
+  name: string
+  ready: number
+  delayed: number
+  reserved: number
+  notify: boolean
+}
+
+export interface LaravelQueueJob {
+  id: string
+  state: 'ready' | 'delayed' | 'reserved'
+  queue: string
+  uuid?: string
+  display_name?: string
+  job?: string
+  command_name?: string
+  attempts: number
+  max_tries?: number
+  timeout?: number
+  backoff?: unknown
+  score?: number
+  available_at?: string
+  payload?: Record<string, unknown>
+  raw: string
+}
+
+export interface LaravelFailedJob {
+  id: number
+  uuid?: string
+  connection: string
+  queue: string
+  payload?: Record<string, unknown>
+  raw_payload: string
+  exception: string
+  failed_at: string
+}
+
+export interface LaravelHorizonSummary {
+  detected: boolean
+  key_count: number
+  supervisors: number
+  masters: number
+  recent_jobs: number
+  failed_jobs: number
+  workload?: Record<string, number>
+  sample_keys: string[]
+}
+
+export interface LaravelQueueFeatureFlags {
+  retry: boolean
+  delete: boolean
+  clear: boolean
+  editedReplay: boolean
+  readOnly: boolean
+  requireConfirm: boolean
+}
+
+export interface LaravelQueueRules {
+  readyMax: number
+  failedMax: number
+  stuckMax: number
+  oldestMinutesMax: number
+  noConsumption: boolean
+}
+
+export interface LaravelQueueOpsSettings {
+  featureFlags: LaravelQueueFeatureFlags
+  queueRules: LaravelQueueRules
+  businessFieldsInput: string
+  sandboxQueue: string
+  environment?: string
+  updated_at?: string
+  updated_by?: number
+}
+
+export interface LaravelQueueAuditItem {
+  id: number
+  conn_id: number
+  failed_conn_id: number
+  user_id: number
+  username: string
+  action: string
+  queue: string
+  target_queue: string
+  job_uuid: string
+  failed_job_id: number
+  payload_edited: boolean
+  status: string
+  error: string
+  details: Record<string, unknown>
+  created_at: string
+}
+
+export interface LaravelQueueQuarantineItem {
+  id: number
+  conn_id: number
+  failed_conn_id: number
+  failed_job_id: number
+  uuid: string
+  queue: string
+  job_name: string
+  payload: string
+  exception: string
+  reason: string
+  status: string
+  created_by: number
+  created_at: string
+  updated_at: string
+}
+
+export function useLaravelQueue() {
+  async function fetchQueues(connId: number, params: { db?: number; prefix?: string }) {
+    const { data } = await axios.get<LaravelQueueSummary[]>(`/api/connections/${connId}/laravel-queue/queues`, {
+      params,
+    })
+    return data
+  }
+
+  async function fetchJobs(connId: number, params: { queue: string; db?: number; prefix?: string; limit?: number }) {
+    const { data } = await axios.get<{ queue: string; jobs: LaravelQueueJob[] }>(`/api/connections/${connId}/laravel-queue/jobs`, {
+      params,
+    })
+    return data
+  }
+
+  async function deleteJob(connId: number, payload: { queue: string; prefix?: string; db?: number; state: LaravelQueueJob['state']; raw: string }) {
+    await axios.post(`/api/connections/${connId}/laravel-queue/delete`, payload)
+  }
+
+  async function requeueJob(connId: number, payload: { queue: string; prefix?: string; db?: number; state: LaravelQueueJob['state']; raw: string }) {
+    await axios.post(`/api/connections/${connId}/laravel-queue/requeue`, payload)
+  }
+
+  async function clearQueue(connId: number, payload: { queue: string; prefix?: string; db?: number; state?: 'all' | LaravelQueueJob['state'] | 'notify' }) {
+    await axios.post(`/api/connections/${connId}/laravel-queue/clear`, payload)
+  }
+
+  async function fetchFailedJobs(connId: number, limit = 100) {
+    const { data } = await axios.get<LaravelFailedJob[]>(`/api/connections/${connId}/laravel-queue/failed-jobs`, {
+      params: { limit },
+    })
+    return data
+  }
+
+  async function retryFailedJob(connId: number, payload: { id: number; redis_conn_id: number; redis_db?: number; prefix?: string; queue: string; payload: string; delete_after: boolean; payload_edited?: boolean }) {
+    await axios.post(`/api/connections/${connId}/laravel-queue/retry-failed`, payload)
+  }
+
+  async function deleteFailedJob(connId: number, id: number, redisConnId?: number) {
+    await axios.post(`/api/connections/${connId}/laravel-queue/delete-failed`, { id, redis_conn_id: redisConnId })
+  }
+
+  async function fetchHorizon(connId: number, db?: number) {
+    const { data } = await axios.get<LaravelHorizonSummary>(`/api/connections/${connId}/laravel-queue/horizon`, {
+      params: { db },
+    })
+    return data
+  }
+
+  async function fetchOpsSettings(connId: number) {
+    const { data } = await axios.get<LaravelQueueOpsSettings>(`/api/connections/${connId}/laravel-queue/ops-settings`)
+    return data
+  }
+
+  async function saveOpsSettings(connId: number, payload: LaravelQueueOpsSettings) {
+    const { data } = await axios.put<LaravelQueueOpsSettings>(`/api/connections/${connId}/laravel-queue/ops-settings`, payload)
+    return data
+  }
+
+  async function fetchQueueAudit(connId: number, limit = 100) {
+    const { data } = await axios.get<LaravelQueueAuditItem[]>(`/api/connections/${connId}/laravel-queue/audit`, { params: { limit } })
+    return data
+  }
+
+  async function fetchQuarantine(connId: number) {
+    const { data } = await axios.get<LaravelQueueQuarantineItem[]>(`/api/connections/${connId}/laravel-queue/quarantine`)
+    return data
+  }
+
+  async function quarantineFailedJob(connId: number, payload: { failed_conn_id: number; failed_job_id: number; uuid?: string; queue: string; job_name: string; payload: string; exception: string; reason?: string }) {
+    await axios.post(`/api/connections/${connId}/laravel-queue/quarantine`, payload)
+  }
+
+  async function releaseQuarantine(connId: number, id: number) {
+    await axios.delete(`/api/connections/${connId}/laravel-queue/quarantine/${id}`)
+  }
+
+  async function emitQueueAlerts(connId: number, payload: { queue: string; prefix: string; alerts: Array<{ level: string; title: string; detail: string }> }) {
+    await axios.post(`/api/connections/${connId}/laravel-queue/alerts`, payload)
+  }
+
+  async function runLaravelAgent(connId: number, payload: { command: string; queue?: string; options?: Record<string, unknown> }) {
+    await axios.post(`/api/connections/${connId}/laravel-queue/agent`, payload)
+  }
+
+  return {
+    fetchQueues,
+    fetchJobs,
+    deleteJob,
+    requeueJob,
+    clearQueue,
+    fetchFailedJobs,
+    retryFailedJob,
+    deleteFailedJob,
+    fetchHorizon,
+    fetchOpsSettings,
+    saveOpsSettings,
+    fetchQueueAudit,
+    fetchQuarantine,
+    quarantineFailedJob,
+    releaseQuarantine,
+    emitQueueAlerts,
+    runLaravelAgent,
+  }
+}

--- a/web/src/composables/useSchema.ts
+++ b/web/src/composables/useSchema.ts
@@ -118,6 +118,9 @@ export function useSchema() {
     try {
       const { data } = await axios.get<SchemaDatabase[]>(`/api/connections/${connId}/schema`)
       databases.value = data
+    } catch (err) {
+      console.error('[useSchema] fetchSchema failed', { connId, err })
+      databases.value = []
     } finally {
       loadingSchema.value = false
     }

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -146,6 +146,12 @@ const router = createRouter({
           meta: { requiredPermissionsAny: ['connections.view', 'schema.browse'] },
         },
         {
+          path: 'laravel-queue',
+          name: 'laravel-queue',
+          component: () => import('@/views/LaravelQueueView.vue'),
+          meta: { requiredPermissionsAny: ['connections.view', 'schema.browse'] },
+        },
+        {
           path: 'connections',
           name: 'connections',
           component: () => import('@/views/ConnectionsView.vue'),

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -239,7 +239,15 @@ onMounted(loadAll)
             <button class="dash-retry-btn" @click="loadOne(conn.id)">Retry</button>
           </div>
 
-          <!-- Stats -->
+          <!-- Redis card -->
+          <template v-else-if="states[conn.id]?.data?.driver === 'redis'">
+            <div class="dash-redis-badge">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M12 12h.01"/><path d="M8 12h.01"/><path d="M16 12h.01"/></svg>
+              Redis key-value store
+            </div>
+          </template>
+
+          <!-- SQL Stats -->
           <template v-else-if="states[conn.id]?.data">
             <div class="dash-conn-card__db">
               <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
@@ -409,6 +417,12 @@ onMounted(loadAll)
   font-size: 11px; color: var(--text-muted); margin-top: 1px;
   font-family: var(--mono, monospace);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+
+.dash-redis-badge {
+  display: flex; align-items: center; gap: 7px;
+  font-size: 12px; font-weight: 500; color: #dc2626;
+  background: #dc262614; border-radius: 6px; padding: 8px 12px;
 }
 
 .dash-conn-card__db {

--- a/web/src/views/DataView.vue
+++ b/web/src/views/DataView.vue
@@ -6,6 +6,7 @@ import { useTheme } from '@/composables/useTheme'
 import { pendingSQL } from '@/composables/usePendingSQL'
 
 const props = defineProps<{ activeConnId?: number | null }>()
+const emit = defineEmits<{ (e: 'set-conn', id: number): void }>()
 
 const { connections } = useConnections()
 const { mode } = useTheme()
@@ -106,10 +107,13 @@ const pickerStyle = computed(() => ({
   zIndex: 9999,
 }))
 
+// Redis connections have no SQL DSN — exclude them from SQL Studio.
+const sqlConns = computed(() => connections.value.filter(c => c.driver !== 'redis'))
+
 const filteredConns = computed(() =>
   pickerSearch.value
-    ? connections.value.filter(c => c.name.toLowerCase().includes(pickerSearch.value.toLowerCase()))
-    : connections.value
+    ? sqlConns.value.filter(c => c.name.toLowerCase().includes(pickerSearch.value.toLowerCase()))
+    : sqlConns.value
 )
 
 function togglePicker() {
@@ -143,9 +147,12 @@ function onDocClick(e: MouseEvent) {
 onMounted(() => document.addEventListener('mousedown', onDocClick, true))
 onBeforeUnmount(() => document.removeEventListener('mousedown', onDocClick, true))
 
-// Bootstrap or switch session when the global active connection changes
+// Bootstrap or switch session when the global active connection changes.
+// Redis connections are excluded — they belong in the Redis Browser, not SQL Studio.
 watch(() => props.activeConnId, (id) => {
   if (id == null) return
+  const conn = connections.value.find(c => c.id === id)
+  if (conn?.driver === 'redis') return
   const existing = sessions.value.find(s => s.connId === id)
   if (existing) {
     // Session already open — just bring it to focus
@@ -173,6 +180,28 @@ onMounted(() => {
 })
 
 function onPickerKeydown(e: KeyboardEvent) { if (e.key === 'Escape') pickerOpen.value = false }
+
+const activeConnIsRedis = computed(() => {
+  if (props.activeConnId == null) return false
+  return connections.value.find(c => c.id === props.activeConnId)?.driver === 'redis'
+})
+
+// Show landing page when there are no sessions OR active conn is Redis
+const showLanding = computed(() => activeConnIsRedis.value || sessions.value.length === 0)
+
+const connDriverColor: Record<string, string> = { postgres: '#336791', mysql: '#f29111', mariadb: '#c0392b', mssql: '#cc2927' }
+const connDriverLabel: Record<string, string> = { postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS' }
+
+// Open a session and also promote it as the global active connection
+function quickOpen(connId: number) {
+  emit('set-conn', connId)
+  const existing = sessions.value.find(s => s.connId === connId)
+  if (existing) {
+    activeSessionId.value = existing.id
+  } else {
+    openSession(connId)
+  }
+}
 
 function handleTableSelected(sessionId: string, db: string, table: string) {
   const session = sessions.value.find(s => s.id === sessionId)
@@ -238,12 +267,49 @@ function handleTableSelected(sessionId: string, db: string, table: string) {
       </div>
     </div>
 
-    <!-- Session panes (kept alive while hidden) -->
-    <div v-if="sessions.length === 0" class="data-empty-state">
-      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" style="opacity:0.3"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg>
-      <div class="data-empty-state__text">
-        <p style="font-size:14px;font-weight:600;margin:0;color:var(--text-primary)">No database sessions open</p>
-        <p style="font-size:13px;margin:6px 0 0;color:var(--text-muted)">Click <strong style="color:var(--brand)">+ DB</strong> to open a database connection</p>
+    <!-- Landing page: shown when no SQL sessions are open OR active conn is Redis -->
+    <div v-if="showLanding" class="dv-landing">
+      <div class="dv-landing__inner">
+
+        <!-- Redis context hint -->
+        <div v-if="activeConnIsRedis" class="dv-landing__redis-hint">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="flex-shrink:0"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M12 12h.01"/><path d="M8 12h.01"/><path d="M16 12h.01"/></svg>
+          The active connection is Redis. SQL Studio requires a relational database — pick one below or use <strong>Database → Redis Browser</strong>.
+        </div>
+
+        <div class="dv-landing__heading">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" style="color:var(--brand)"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
+          <span>Open a database connection</span>
+        </div>
+        <p class="dv-landing__sub">Click any connection to open it in a new session tab.</p>
+
+        <!-- No SQL connections at all -->
+        <div v-if="sqlConns.length === 0" class="dv-landing__empty">
+          No relational database connections found. Add one in <strong>Admin → Connections</strong>.
+        </div>
+
+        <!-- SQL connection cards -->
+        <div v-else class="dv-landing__grid">
+          <button
+            v-for="conn in sqlConns"
+            :key="conn.id"
+            class="dv-conn-card"
+            :class="{ 'dv-conn-card--active': conn.id === props.activeConnId }"
+            @click="quickOpen(conn.id)"
+          >
+            <div class="dv-conn-card__badge" :style="{ background: connDriverColor[conn.driver] ?? '#888' }">
+              {{ connDriverLabel[conn.driver] ?? '??' }}
+            </div>
+            <div class="dv-conn-card__info">
+              <div class="dv-conn-card__name">{{ conn.name }}</div>
+              <div class="dv-conn-card__host">{{ conn.host }}{{ conn.port ? ':' + conn.port : '' }}</div>
+            </div>
+            <div class="dv-conn-card__open">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+            </div>
+          </button>
+        </div>
+
       </div>
     </div>
 
@@ -427,19 +493,144 @@ function handleTableSelected(sessionId: string, db: string, table: string) {
   flex-shrink: 0;
 }
 
-/* ── Empty State ──────────────────────────────────────────────── */
-.data-empty-state {
+/* ── Landing page ─────────────────────────────────────────────── */
+.dv-landing {
   flex: 1;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
-  color: var(--text-muted);
-  padding: 40px;
-  text-align: center;
+  overflow-y: auto;
+  padding: 40px 24px;
+  background: var(--bg-body);
 }
-.data-empty-state__text {
-  max-width: 400px;
+
+.dv-landing__inner {
+  width: 100%;
+  max-width: 580px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.dv-landing__redis-hint {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 11px 14px;
+  border: 1px solid #c6302b44;
+  border-radius: 8px;
+  background: #c6302b0c;
+  color: #c6302b;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.dv-landing__heading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 17px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.dv-landing__sub {
+  margin: -12px 0 0;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.dv-landing__empty {
+  padding: 20px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-muted);
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+}
+
+.dv-landing__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dv-conn-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-surface);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.15s, background 0.15s, transform 0.12s, box-shadow 0.15s;
+}
+.dv-conn-card:hover {
+  border-color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 5%, var(--bg-surface));
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(0,0,0,.08);
+}
+.dv-conn-card--active {
+  border-color: var(--brand);
+  background: var(--brand-dim);
+}
+
+.dv-conn-card__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 28px;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+  letter-spacing: 0.3px;
+}
+
+.dv-conn-card__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.dv-conn-card__name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dv-conn-card__host {
+  font-size: 11.5px;
+  color: var(--text-muted);
+  font-family: var(--mono, monospace);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dv-conn-card__open {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  flex-shrink: 0;
+  transition: background 0.12s, color 0.12s;
+}
+.dv-conn-card:hover .dv-conn-card__open {
+  background: var(--brand);
+  color: #fff;
 }
 </style>

--- a/web/src/views/LaravelQueueView.vue
+++ b/web/src/views/LaravelQueueView.vue
@@ -1,0 +1,2516 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+function debounce<T extends (...args: unknown[]) => void>(fn: T, ms: number): T {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  return ((...args: unknown[]) => {
+    if (timer !== null) clearTimeout(timer)
+    timer = setTimeout(() => { timer = null; fn(...args) }, ms)
+  }) as T
+}
+import { useConnections } from '@/composables/useConnections'
+import { useLaravelQueue, type LaravelFailedJob, type LaravelHorizonSummary, type LaravelQueueAuditItem, type LaravelQueueFeatureFlags, type LaravelQueueJob, type LaravelQueueQuarantineItem, type LaravelQueueRules, type LaravelQueueSummary } from '@/composables/useLaravelQueue'
+import { useToast } from '@/composables/useToast'
+import { useConfirm } from '@/composables/useConfirm'
+
+const props = defineProps<{ activeConnId: number | null }>()
+const emit = defineEmits<{ (e: 'set-conn', id: number): void }>()
+
+const { connections, fetchConnections } = useConnections()
+const {
+  fetchQueues,
+  fetchJobs,
+  deleteJob,
+  requeueJob,
+  clearQueue,
+  fetchFailedJobs,
+  retryFailedJob,
+  deleteFailedJob,
+  fetchHorizon,
+  fetchOpsSettings,
+  saveOpsSettings,
+  fetchQueueAudit,
+  fetchQuarantine,
+  quarantineFailedJob,
+  releaseQuarantine,
+  emitQueueAlerts,
+  runLaravelAgent,
+} = useLaravelQueue()
+const toast = useToast()
+const { confirm } = useConfirm()
+
+const selectedDb = ref(0)
+const prefix = ref('queues')
+const queues = ref<LaravelQueueSummary[]>([])
+const selectedQueue = ref('default')
+const jobs = ref<LaravelQueueJob[]>([])
+const failedJobs = ref<LaravelFailedJob[]>([])
+const horizon = ref<LaravelHorizonSummary | null>(null)
+const selectedJobId = ref('')
+const selectedFailedJobId = ref<number | null>(null)
+const activeState = ref<'all' | 'ready' | 'delayed' | 'reserved' | 'failed'>('all')
+const detailTab = ref<'summary' | 'main' | 'payload' | 'command' | 'exception'>('summary')
+const insightTab = ref<'health' | 'timeline' | 'groups' | 'patterns' | 'quarantine' | 'controls' | 'settings' | 'audit'>('health')
+const failedGroupBy = ref<'job' | 'exception' | 'queue' | 'date'>('job')
+const search = ref('')
+const retryAfter = ref(90)
+const autoRefresh = ref(false)
+const refreshSeconds = ref(10)
+const failedConnId = ref<number | null>(null)
+const loadingQueues = ref(false)
+const loadingJobs = ref(false)
+const loadingFailed = ref(false)
+const selectedJobIds = ref(new Set<string>())
+const selectedFailedJobIds = ref(new Set<number>())
+const profileName = ref('')
+const selectedProfile = ref('')
+const profiles = ref<QueueProfile[]>([])
+const pendingProfile = ref<QueueProfile | null>(null)
+const timeline = ref<QueueTimelineSample[]>([])
+const editedFailedPayload = ref('')
+const sandboxQueue = ref('debug')
+const businessFieldsInput = ref('tenant_id,user_id,order_id,invoice_id,email,amount')
+const quarantine = ref<LaravelQueueQuarantineItem[]>([])
+const queueAudit = ref<LaravelQueueAuditItem[]>([])
+const opsSettingsLoaded = ref(false)
+const savingOpsSettings = ref(false)
+const featureFlags = ref<LaravelQueueFeatureFlags>({
+  retry: true,
+  delete: true,
+  clear: true,
+  editedReplay: true,
+  readOnly: false,
+  requireConfirm: true,
+})
+const queueRules = ref<LaravelQueueRules>({
+  readyMax: 100,
+  failedMax: 10,
+  stuckMax: 0,
+  oldestMinutesMax: 30,
+  noConsumption: true,
+})
+
+interface QueueProfile {
+  name: string
+  redisConnId: number | null
+  redisDb: number
+  prefix: string
+  queue: string
+  failedConnId: number | null
+  retryAfter: number
+}
+
+interface QueueTimelineSample {
+  at: string
+  ready: number
+  delayed: number
+  reserved: number
+  failed: number
+  stuck: number
+}
+
+type JsonLike = null | boolean | number | string | JsonLike[] | { [key: string]: JsonLike }
+
+interface MainDataResult {
+  title: string
+  data: Record<string, unknown>
+  rawCommand?: string
+}
+
+const redisDbIndexes = Array.from({ length: 16 }, (_, index) => index)
+const redisConnections = computed(() => connections.value.filter((c) => c.driver === 'redis'))
+const sqlConnections = computed(() => connections.value.filter((c) => c.driver !== 'redis'))
+const activeConn = computed(() =>
+  props.activeConnId != null ? connections.value.find((c) => c.id === props.activeConnId) ?? null : null,
+)
+const isRedis = computed(() => activeConn.value?.driver === 'redis')
+const filteredJobs = computed(() => {
+  const query = search.value.trim().toLowerCase()
+  return jobs.value.filter((job) => {
+    if (activeState.value !== 'all' && job.state !== activeState.value) return false
+    if (!query) return true
+    return [
+      job.uuid,
+      job.display_name,
+      job.command_name,
+      job.job,
+      job.raw,
+    ].some(value => String(value || '').toLowerCase().includes(query))
+  })
+})
+const selectedJob = computed(() => jobs.value.find(job => job.id === selectedJobId.value) ?? filteredJobs.value[0] ?? null)
+const filteredFailedJobs = computed(() => {
+  const query = search.value.trim().toLowerCase()
+  return failedJobs.value.filter((job) => {
+    if (!query) return true
+    return [
+      job.uuid,
+      job.connection,
+      job.queue,
+      job.raw_payload,
+      job.exception,
+    ].some(value => String(value || '').toLowerCase().includes(query))
+  })
+})
+const selectedFailedJob = computed(() => failedJobs.value.find(job => job.id === selectedFailedJobId.value) ?? filteredFailedJobs.value[0] ?? null)
+const selectedSummary = computed(() => queues.value.find(queue => queue.name === selectedQueue.value) ?? null)
+const stuckJobs = computed(() => jobs.value.filter(isStuckJob))
+const selectedJobs = computed(() => jobs.value.filter(job => selectedJobIds.value.has(job.id)))
+const selectedFailedJobs = computed(() => failedJobs.value.filter(job => selectedFailedJobIds.value.has(job.id)))
+const allVisibleJobsSelected = computed(() => filteredJobs.value.length > 0 && filteredJobs.value.every(job => selectedJobIds.value.has(job.id)))
+const allVisibleFailedJobsSelected = computed(() => filteredFailedJobs.value.length > 0 && filteredFailedJobs.value.every(job => selectedFailedJobIds.value.has(job.id)))
+const oldestJobAge = computed(() => {
+  const scored = jobs.value.filter(job => job.score && job.score > 0)
+  if (!scored.length) return '-'
+  const oldest = Math.min(...scored.map(job => job.score || 0))
+  return ageLabel(oldest)
+})
+const queueTotals = computed(() => queues.value.reduce((total, queue) => ({
+  ready: total.ready + queue.ready,
+  delayed: total.delayed + queue.delayed,
+  reserved: total.reserved + queue.reserved,
+}), { ready: 0, delayed: 0, reserved: 0 }))
+const businessFields = computed(() => businessFieldsInput.value.split(',').map(field => field.trim()).filter(Boolean))
+const oldestJobAgeMinutes = computed(() => {
+  const scored = jobs.value.filter(job => job.score && job.score > 0)
+  if (!scored.length) return 0
+  const oldest = Math.min(...scored.map(job => job.score || 0))
+  return Math.floor((Date.now() / 1000 - oldest) / 60)
+})
+const queueAlerts = computed(() => {
+  const alerts: Array<{ level: 'danger' | 'warning'; title: string; detail: string }> = []
+  if (queueRules.value.readyMax > 0 && queueTotals.value.ready > queueRules.value.readyMax) {
+    alerts.push({ level: 'warning', title: 'Ready threshold exceeded', detail: `${queueTotals.value.ready} ready jobs > ${queueRules.value.readyMax}.` })
+  }
+  if (queueRules.value.failedMax > 0 && failedJobs.value.length > queueRules.value.failedMax) {
+    alerts.push({ level: 'danger', title: 'Failed threshold exceeded', detail: `${failedJobs.value.length} failed jobs > ${queueRules.value.failedMax}.` })
+  }
+  if (stuckJobs.value.length > queueRules.value.stuckMax) {
+    alerts.push({ level: 'danger', title: 'Stuck threshold exceeded', detail: `${stuckJobs.value.length} stuck jobs > ${queueRules.value.stuckMax}.` })
+  }
+  if (queueRules.value.oldestMinutesMax > 0 && oldestJobAgeMinutes.value > queueRules.value.oldestMinutesMax) {
+    alerts.push({ level: 'warning', title: 'Oldest job age exceeded', detail: `${oldestJobAgeMinutes.value} minutes > ${queueRules.value.oldestMinutesMax}.` })
+  }
+  if (queueRules.value.noConsumption && queueTotals.value.ready > 0 && !queueTotals.value.reserved && !horizon.value?.supervisors) {
+    alerts.push({ level: 'warning', title: 'No consumption detected', detail: 'Ready jobs exist, but no reserved jobs or Horizon supervisors were detected.' })
+  }
+  return alerts
+})
+const healthIssues = computed(() => {
+  const issues: Array<{ level: 'danger' | 'warning' | 'ok'; title: string; detail: string }> = []
+  for (const alert of queueAlerts.value) issues.push(alert)
+  if (stuckJobs.value.length) {
+    issues.push({
+      level: 'danger',
+      title: 'Reserved jobs past retry_after',
+      detail: `${stuckJobs.value.length} job${stuckJobs.value.length === 1 ? '' : 's'} reserved longer than ${retryAfter.value}s.`,
+    })
+  }
+  if (queueTotals.value.ready > 0 && !queueTotals.value.reserved && !horizon.value?.supervisors) {
+    issues.push({
+      level: 'warning',
+      title: 'Queue may not be consuming',
+      detail: `${queueTotals.value.ready} ready job${queueTotals.value.ready === 1 ? '' : 's'} and no reserved jobs or Horizon supervisors detected.`,
+    })
+  }
+  if (failedJobs.value.length >= 25) {
+    issues.push({
+      level: 'warning',
+      title: 'Failed jobs are accumulating',
+      detail: `${failedJobs.value.length} failed job rows are currently loaded.`,
+    })
+  }
+  if (queueTotals.value.delayed > 0 && stateCount('delayed') > 0) {
+    const due = jobs.value.filter(job => job.state === 'delayed' && job.score && job.score <= Math.floor(Date.now() / 1000)).length
+    if (due) {
+      issues.push({
+        level: 'warning',
+        title: 'Delayed jobs are due',
+        detail: `${due} delayed job${due === 1 ? '' : 's'} appear ready to move back to the queue.`,
+      })
+    }
+  }
+  if (horizon.value?.detected && !horizon.value.supervisors) {
+    issues.push({
+      level: 'warning',
+      title: 'Horizon detected without supervisors',
+      detail: 'Horizon keys exist, but no active supervisors were found in the sampled data.',
+    })
+  }
+  if (!issues.length) {
+    issues.push({
+      level: 'ok',
+      title: 'No obvious queue issue detected',
+      detail: 'Current ready, delayed, reserved, failed, and Horizon signals look normal.',
+    })
+  }
+  return issues
+})
+const failedGroups = computed(() => {
+  const groups = new Map<string, { key: string; count: number; latest: string; sample: LaravelFailedJob }>()
+  for (const job of failedJobs.value) {
+    const key = failedGroupKey(job)
+    const existing = groups.get(key)
+    if (existing) {
+      existing.count += 1
+      if (new Date(job.failed_at).getTime() > new Date(existing.latest).getTime()) existing.latest = job.failed_at
+    } else {
+      groups.set(key, { key, count: 1, latest: job.failed_at, sample: job })
+    }
+  }
+  return [...groups.values()].sort((a, b) => b.count - a.count || b.latest.localeCompare(a.latest))
+})
+const failedPatterns = computed(() => {
+  const groups = new Map<string, { key: string; count: number; latest: string; sample: LaravelFailedJob; reasons: string[] }>()
+  for (const job of failedJobs.value) {
+    for (const pattern of patternKeys(job)) {
+      const existing = groups.get(pattern.key)
+      if (existing) {
+        existing.count += 1
+        if (new Date(job.failed_at).getTime() > new Date(existing.latest).getTime()) existing.latest = job.failed_at
+      } else {
+        groups.set(pattern.key, { key: pattern.key, count: 1, latest: job.failed_at, sample: job, reasons: [pattern.type] })
+      }
+    }
+  }
+  return [...groups.values()].filter(group => group.count > 1).sort((a, b) => b.count - a.count || b.latest.localeCompare(a.latest)).slice(0, 18)
+})
+const quarantinedFailedJobIds = computed(() => new Set(quarantine.value.map(item => item.failed_job_id)))
+const quarantinedFailedJobs = computed(() => failedJobs.value.filter(job => quarantinedFailedJobIds.value.has(job.id)))
+const maxTimelineTotal = computed(() => Math.max(1, ...timeline.value.map(sample => sample.ready + sample.delayed + sample.reserved + sample.failed)))
+let refreshTimer: number | null = null
+
+onMounted(async () => {
+  loadProfiles()
+  if (!connections.value.length) await fetchConnections()
+  if (!isRedis.value && redisConnections.value.length === 1) {
+    emit('set-conn', redisConnections.value[0].id)
+    return
+  }
+  selectedDb.value = Number(activeConn.value?.database || 0)
+  failedConnId.value = sqlConnections.value[0]?.id ?? null
+  if (isRedis.value) {
+    await loadOpsSettings()
+    await Promise.all([loadQueues(), loadHorizon(), loadQuarantine(), loadQueueAudit()])
+  }
+})
+
+onBeforeUnmount(() => stopAutoRefresh())
+
+watch(() => props.activeConnId, async () => {
+  const profile = pendingProfile.value
+  if (profile && profile.redisConnId === props.activeConnId) {
+    selectedDb.value = profile.redisDb
+    prefix.value = profile.prefix
+    selectedQueue.value = profile.queue
+    failedConnId.value = profile.failedConnId
+    retryAfter.value = profile.retryAfter
+    pendingProfile.value = null
+  } else {
+    selectedDb.value = Number(activeConn.value?.database || 0)
+  }
+  selectedJobId.value = ''
+  selectedJobIds.value = new Set()
+  selectedFailedJobIds.value = new Set()
+  queues.value = []
+  jobs.value = []
+  if (isRedis.value) {
+    await loadOpsSettings()
+    await Promise.all([loadQueues(), loadHorizon(), loadQuarantine(), loadQueueAudit()])
+  }
+})
+
+watch([autoRefresh, refreshSeconds], () => {
+  stopAutoRefresh()
+  if (autoRefresh.value) {
+    refreshTimer = window.setInterval(refreshCurrentView, Math.max(3, Number(refreshSeconds.value || 10)) * 1000)
+  }
+})
+
+watch(failedConnId, async () => {
+  selectedFailedJobId.value = null
+  if (failedConnId.value) await loadFailedJobs()
+})
+
+watch([selectedDb, prefix], async () => {
+  selectedJobId.value = ''
+  selectedJobIds.value = new Set()
+  if (isRedis.value) await loadQueues()
+})
+
+watch(selectedQueue, async () => {
+  selectedJobId.value = ''
+  selectedJobIds.value = new Set()
+  if (isRedis.value) await loadJobs()
+})
+
+watch(selectedFailedJob, (job) => {
+  editedFailedPayload.value = job ? formatFailedPayload(job) : ''
+}, { immediate: true })
+
+const debouncedPersistOpsSettings = debounce(() => persistOpsSettings(), 600)
+watch([featureFlags, queueRules, businessFieldsInput, sandboxQueue], () => debouncedPersistOpsSettings(), { deep: true })
+
+async function loadQueues() {
+  if (!activeConn.value || !isRedis.value) return
+  loadingQueues.value = true
+  try {
+    queues.value = await fetchQueues(activeConn.value.id, { db: selectedDb.value, prefix: prefix.value })
+    if (!queues.value.some(queue => queue.name === selectedQueue.value)) {
+      selectedQueue.value = queues.value[0]?.name ?? 'default'
+    }
+    await loadJobs()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to load Laravel queues'))
+  } finally {
+    loadingQueues.value = false
+  }
+}
+
+async function loadJobs() {
+  if (!activeConn.value || !isRedis.value || !selectedQueue.value) return
+  loadingJobs.value = true
+  try {
+    const data = await fetchJobs(activeConn.value.id, {
+      queue: selectedQueue.value,
+      db: selectedDb.value,
+      prefix: prefix.value,
+      limit: 100,
+    })
+    jobs.value = data.jobs
+    selectedJobId.value = filteredJobs.value[0]?.id ?? ''
+    selectedJobIds.value = new Set([...selectedJobIds.value].filter(id => jobs.value.some(job => job.id === id)))
+    recordTimelineSample()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to load Laravel queue jobs'))
+  } finally {
+    loadingJobs.value = false
+  }
+}
+
+async function loadHorizon() {
+  if (!activeConn.value || !isRedis.value) return
+  try {
+    horizon.value = await fetchHorizon(activeConn.value.id, selectedDb.value)
+  } catch {
+    horizon.value = null
+  }
+}
+
+async function loadFailedJobs() {
+  if (!failedConnId.value) return
+  loadingFailed.value = true
+  try {
+    failedJobs.value = await fetchFailedJobs(failedConnId.value, 100)
+    selectedFailedJobId.value = filteredFailedJobs.value[0]?.id ?? null
+    selectedFailedJobIds.value = new Set([...selectedFailedJobIds.value].filter(id => failedJobs.value.some(job => job.id === id)))
+    recordTimelineSample()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to load Laravel failed jobs'))
+  } finally {
+    loadingFailed.value = false
+  }
+}
+
+function selectRedisConnection(rawId: string | number) {
+  const id = Number(rawId)
+  if (Number.isFinite(id)) emit('set-conn', id)
+}
+
+function stateCount(state: LaravelQueueJob['state']) {
+  return jobs.value.filter(job => job.state === state).length
+}
+
+function commandData(job: LaravelQueueJob | null) {
+  const data = job?.payload?.data
+  return data && typeof data === 'object' ? JSON.stringify(data, null, 2) : ''
+}
+
+function failedCommandData(job: LaravelFailedJob | null) {
+  const data = job?.payload?.data
+  return data && typeof data === 'object' ? JSON.stringify(data, null, 2) : ''
+}
+
+function mainDataForJob(job: LaravelQueueJob | null) {
+  if (!job) return ''
+  return JSON.stringify(extractMainData(job.payload, {
+    queue: job.queue,
+    uuid: job.uuid,
+    attempts: job.attempts,
+    state: job.state,
+  }), null, 2)
+}
+
+function mainDataForFailedJob(job: LaravelFailedJob | null) {
+  if (!job) return ''
+  return JSON.stringify(extractMainData(job.payload, {
+    queue: job.queue,
+    uuid: job.uuid,
+    failed_at: job.failed_at,
+    connection: job.connection,
+  }), null, 2)
+}
+
+function isStuckJob(job: LaravelQueueJob) {
+  if (job.state !== 'reserved' || !job.score) return false
+  return job.score < Math.floor(Date.now() / 1000) - Number(retryAfter.value || 0)
+}
+
+function ageLabel(score: number) {
+  const seconds = Math.max(0, Math.floor(Date.now() / 1000) - score)
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`
+  return `${Math.floor(seconds / 86400)}d`
+}
+
+function formatDate(raw?: string) {
+  if (!raw) return '-'
+  const date = new Date(raw)
+  return Number.isNaN(date.getTime()) ? raw : date.toLocaleString()
+}
+
+function formatPayload(job: LaravelQueueJob | null) {
+  if (!job) return ''
+  return JSON.stringify(job.payload ?? safeParse(job.raw) ?? job.raw, null, 2)
+}
+
+function formatFailedPayload(job: LaravelFailedJob | null) {
+  if (!job) return ''
+  return JSON.stringify(job.payload ?? safeParse(job.raw_payload) ?? job.raw_payload, null, 2)
+}
+
+function safeParse(raw: string) {
+  try { return JSON.parse(raw) } catch { return null }
+}
+
+function isValidJson(raw: string) {
+  try {
+    JSON.parse(raw)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function extractMainData(payload: Record<string, unknown> | undefined, meta: Record<string, unknown>): MainDataResult {
+  if (!payload) return { title: 'No payload found', data: meta }
+  const data = isRecord(payload.data) ? payload.data : {}
+  const command = typeof data.command === 'string' ? data.command : ''
+  const commandName = String(payload.displayName || data.commandName || payload.job || 'Laravel job')
+  const main: Record<string, unknown> = {
+    job: commandName,
+    ...compactRecord(meta),
+  }
+
+  const directData = compactRecord(pickReadableFields(data))
+  delete directData.command
+  delete directData.commandName
+  Object.assign(main, directData)
+
+  const decoded = command ? decodeLaravelCommand(command) : {}
+  Object.assign(main, compactRecord(decoded))
+  const context = pickBusinessContext(main)
+  if (Object.keys(context).length) {
+    main.business_context = context
+  }
+
+  return {
+    title: commandName,
+    data: main,
+    rawCommand: command || undefined,
+  }
+}
+
+function pickBusinessContext(value: unknown): Record<string, unknown> {
+  const result: Record<string, unknown> = {}
+  collectBusinessContext(value, result, 0)
+  return result
+}
+
+function collectBusinessContext(value: unknown, result: Record<string, unknown>, depth: number) {
+  if (depth > 5 || !isRecord(value)) return
+  for (const [key, raw] of Object.entries(value)) {
+    if (businessFields.value.includes(key) && !isEmptyValue(raw)) {
+      result[key] = raw
+    }
+    if (isRecord(raw)) collectBusinessContext(raw, result, depth + 1)
+    if (Array.isArray(raw)) {
+      for (const item of raw) collectBusinessContext(item, result, depth + 1)
+    }
+  }
+}
+
+function pickReadableFields(value: unknown): Record<string, unknown> {
+  if (!isRecord(value)) return {}
+  const ignored = new Set([
+    'command',
+    'commandName',
+    'middleware',
+    'chained',
+    'chainConnection',
+    'chainQueue',
+    'chainCatchCallbacks',
+    'delay',
+    'afterCommit',
+    'backoff',
+    'timeout',
+    'tries',
+    'maxExceptions',
+    'failOnTimeout',
+    'retryUntil',
+    'uuid',
+  ])
+  const result: Record<string, unknown> = {}
+  for (const [key, raw] of Object.entries(value)) {
+    const cleanKey = cleanPhpPropertyName(key)
+    if (!cleanKey || ignored.has(cleanKey)) continue
+    const normalized = normalizeMainValue(raw, 0)
+    if (normalized !== undefined && !isEmptyValue(normalized)) result[cleanKey] = normalized
+  }
+  return result
+}
+
+function decodeLaravelCommand(raw: string): Record<string, unknown> {
+  const parsed = parsePhpSerialized(raw)
+  const result: Record<string, unknown> = {}
+  if (parsed !== undefined) {
+    const normalized = normalizeMainValue(parsed, 0)
+    if (isRecord(normalized)) Object.assign(result, pickReadableFields(normalized))
+    else if (normalized !== undefined) result.command_value = normalized
+  }
+
+  const models = extractSerializedModels(raw)
+  if (models.length) result.models = models
+
+  if (!Object.keys(result).length) {
+    const scalarFields = extractSerializedScalarFields(raw)
+    Object.assign(result, scalarFields)
+  }
+  return result
+}
+
+function parsePhpSerialized(raw: string): unknown {
+  let index = 0
+
+  function readUntil(char: string) {
+    const end = raw.indexOf(char, index)
+    if (end < 0) throw new Error('Invalid serialized payload')
+    const value = raw.slice(index, end)
+    index = end + 1
+    return value
+  }
+
+  function readValue(): unknown {
+    const type = raw[index]
+    index += 2
+    if (type === 'N') {
+      index -= 1
+      if (raw[index] !== ';') throw new Error('Invalid null')
+      index += 1
+      return null
+    }
+    if (type === 'b') {
+      const value = readUntil(';')
+      return value === '1'
+    }
+    if (type === 'i') return Number(readUntil(';'))
+    if (type === 'd') return Number(readUntil(';'))
+    if (type === 's') {
+      const length = Number(readUntil(':'))
+      if (raw[index] !== '"') throw new Error('Invalid string')
+      index += 1
+      const value = raw.slice(index, index + length)
+      index += length + 2
+      return value
+    }
+    if (type === 'a') {
+      const length = Number(readUntil(':'))
+      if (raw[index] !== '{') throw new Error('Invalid array')
+      index += 1
+      const entries: Array<[unknown, unknown]> = []
+      for (let i = 0; i < length; i += 1) entries.push([readValue(), readValue()])
+      if (raw[index] !== '}') throw new Error('Invalid array close')
+      index += 1
+      return entriesToObject(entries)
+    }
+    if (type === 'O' || type === 'C') {
+      const classLength = Number(readUntil(':'))
+      if (raw[index] !== '"') throw new Error('Invalid class')
+      index += 1
+      const className = raw.slice(index, index + classLength)
+      index += classLength + 2
+      const propCount = Number(readUntil(':'))
+      if (raw[index] !== '{') throw new Error('Invalid object')
+      index += 1
+      const objectValue: Record<string, unknown> = { class: className }
+      for (let i = 0; i < propCount; i += 1) {
+        const key = cleanPhpPropertyName(String(readValue() ?? ''))
+        objectValue[key] = readValue()
+      }
+      if (raw[index] !== '}') throw new Error('Invalid object close')
+      index += 1
+      return objectValue
+    }
+    throw new Error(`Unsupported serialized type ${type}`)
+  }
+
+  try {
+    return readValue()
+  } catch {
+    return undefined
+  }
+}
+
+function entriesToObject(entries: Array<[unknown, unknown]>) {
+  const isList = entries.every(([key], index) => Number(key) === index)
+  if (isList) return entries.map(([, value]) => value)
+  return entries.reduce<Record<string, unknown>>((acc, [key, value]) => {
+    acc[cleanPhpPropertyName(String(key))] = value
+    return acc
+  }, {})
+}
+
+function normalizeMainValue(value: unknown, depth: number): JsonLike | undefined {
+  if (depth > 4) return undefined
+  if (value == null || ['string', 'number', 'boolean'].includes(typeof value)) return value as JsonLike
+  if (Array.isArray(value)) {
+    const list = value.map(item => normalizeMainValue(item, depth + 1)).filter(item => item !== undefined) as JsonLike[]
+    return list.length ? list : undefined
+  }
+  if (!isRecord(value)) return undefined
+
+  const result: Record<string, JsonLike> = {}
+  for (const [rawKey, rawValue] of Object.entries(value)) {
+    const key = cleanPhpPropertyName(rawKey)
+    if (!key || key.startsWith('__')) continue
+    const normalized = normalizeMainValue(rawValue, depth + 1)
+    if (normalized !== undefined && !isEmptyValue(normalized)) result[key] = normalized
+  }
+  return Object.keys(result).length ? result : undefined
+}
+
+function extractSerializedModels(raw: string) {
+  const models: Array<Record<string, unknown>> = []
+  const regex = /ModelIdentifier.+?s:5:"class";s:\d+:"([^"]+)".+?s:2:"id";(?:i:(\d+);|s:\d+:"([^"]+)")/gs
+  for (const match of raw.matchAll(regex)) {
+    models.push({
+      class: match[1],
+      id: match[2] || match[3],
+    })
+  }
+  return models
+}
+
+function extractSerializedScalarFields(raw: string) {
+  const fields: Record<string, unknown> = {}
+  const regex = /s:\d+:"\u0000?\*?\u0000?([^"]+)";(?:s:\d+:"([^"]*)"|i:(-?\d+)|b:([01])|d:([-0-9.]+));/g
+  for (const match of raw.matchAll(regex)) {
+    const key = cleanPhpPropertyName(match[1])
+    if (!key || key.length > 80) continue
+    if (match[2] != null && match[2] !== '') fields[key] = match[2]
+    else if (match[3] != null) fields[key] = Number(match[3])
+    else if (match[4] != null) fields[key] = match[4] === '1'
+    else if (match[5] != null) fields[key] = Number(match[5])
+  }
+  return compactRecord(fields)
+}
+
+function cleanPhpPropertyName(key: string) {
+  return key.replace(/\u0000\*\u0000/g, '').replace(/\u0000[^]*\u0000/g, '').trim()
+}
+
+function compactRecord(record: Record<string, unknown>) {
+  return Object.entries(record).reduce<Record<string, unknown>>((acc, [key, value]) => {
+    if (value !== undefined && !isEmptyValue(value)) acc[key] = value
+    return acc
+  }, {})
+}
+
+function isEmptyValue(value: unknown) {
+  if (value == null || value === '') return true
+  if (Array.isArray(value)) return value.length === 0
+  return isRecord(value) && Object.keys(value).length === 0
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function failedGroupKey(job: LaravelFailedJob) {
+  if (failedGroupBy.value === 'queue') return job.queue || 'default'
+  if (failedGroupBy.value === 'date') return (job.failed_at || '').slice(0, 10) || 'unknown date'
+  if (failedGroupBy.value === 'exception') {
+    const firstLine = job.exception?.split('\n')[0] || 'Unknown exception'
+    return firstLine.replace(/^([A-Za-z0-9_\\]+).*$/, '$1') || firstLine
+  }
+  return String(job.payload?.displayName || job.payload?.job || job.uuid || 'Unknown job')
+}
+
+function patternKeys(job: LaravelFailedJob) {
+  const main = extractMainData(job.payload, { queue: job.queue, uuid: job.uuid }).data
+  const context = isRecord(main.business_context) ? main.business_context : {}
+  const modelIds = Array.isArray(main.models) ? main.models : []
+  const exception = job.exception?.split('\n')[0] || 'Unknown exception'
+  const keys = [
+    { type: 'job', key: `Job: ${String(job.payload?.displayName || job.payload?.job || job.uuid || 'Unknown job')}` },
+    { type: 'exception', key: `Exception: ${exception.replace(/^([A-Za-z0-9_\\]+).*$/, '$1')}` },
+    { type: 'queue', key: `Queue: ${job.queue || 'default'}` },
+  ]
+  for (const [field, value] of Object.entries(context)) {
+    keys.push({ type: field, key: `${field}: ${String(value)}` })
+  }
+  for (const model of modelIds) {
+    if (isRecord(model) && model.class && model.id) keys.push({ type: 'model', key: `Model: ${model.class}#${model.id}` })
+  }
+  return keys
+}
+
+function canAction(action: 'retry' | 'delete' | 'clear' | 'editedReplay') {
+  if (featureFlags.value.readOnly) return false
+  return featureFlags.value[action]
+}
+
+async function confirmAction(action: 'retry' | 'delete' | 'clear' | 'editedReplay', message: string, title: string) {
+  if (!canAction(action)) {
+    toast.error(featureFlags.value.readOnly ? 'Read-only mode is enabled' : `${title} is disabled by feature flags`)
+    return false
+  }
+  return featureFlags.value.requireConfirm ? confirm(message, title) : true
+}
+
+async function loadOpsSettings() {
+  if (!activeConn.value) return
+  opsSettingsLoaded.value = false
+  try {
+    const settings = await fetchOpsSettings(activeConn.value.id)
+    featureFlags.value = { ...featureFlags.value, ...(settings.featureFlags || {}) }
+    queueRules.value = { ...queueRules.value, ...(settings.queueRules || {}) }
+    businessFieldsInput.value = settings.businessFieldsInput || businessFieldsInput.value
+    sandboxQueue.value = settings.sandboxQueue || sandboxQueue.value
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to load queue operations settings'))
+  } finally {
+    opsSettingsLoaded.value = true
+  }
+}
+
+async function persistOpsSettings() {
+  if (!activeConn.value || !opsSettingsLoaded.value || savingOpsSettings.value) return
+  savingOpsSettings.value = true
+  try {
+    await saveOpsSettings(activeConn.value.id, {
+      featureFlags: featureFlags.value,
+      queueRules: queueRules.value,
+      businessFieldsInput: businessFieldsInput.value,
+      sandboxQueue: sandboxQueue.value,
+      environment: 'default',
+    })
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to save queue operations settings'))
+  } finally {
+    savingOpsSettings.value = false
+  }
+}
+
+async function loadQuarantine() {
+  if (!activeConn.value) return
+  try {
+    quarantine.value = await fetchQuarantine(activeConn.value.id)
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to load queue quarantine'))
+  }
+}
+
+async function loadQueueAudit() {
+  if (!activeConn.value) return
+  try {
+    queueAudit.value = await fetchQueueAudit(activeConn.value.id, 100)
+  } catch {
+    queueAudit.value = []
+  }
+}
+
+async function quarantineSelectedFailed() {
+  const results = await Promise.allSettled(selectedFailedJobs.value.map(job => quarantineFailed(job, false)))
+  await loadQuarantine()
+  const failed = results.filter(r => r.status === 'rejected').length
+  if (failed > 0) {
+    toast.error(`${failed} job${failed === 1 ? '' : 's'} failed to quarantine`)
+  } else {
+    toast.success('Selected failed jobs moved to quarantine')
+  }
+}
+
+async function quarantineFailed(job: LaravelFailedJob | null, notify = true) {
+  if (!activeConn.value || !failedConnId.value || !job) return
+  try {
+    await quarantineFailedJob(activeConn.value.id, {
+      failed_conn_id: failedConnId.value,
+      failed_job_id: job.id,
+      uuid: job.uuid,
+      queue: job.queue,
+      job_name: String(job.payload?.displayName || job.payload?.job || job.uuid || `failed_jobs #${job.id}`),
+      payload: job.raw_payload,
+      exception: job.exception,
+      reason: 'manual review',
+    })
+    await loadQuarantine()
+    await loadQueueAudit()
+    if (notify) toast.success('Failed job moved to quarantine')
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to quarantine job'))
+  }
+}
+
+async function removeFromQuarantine(job: LaravelFailedJob) {
+  if (!activeConn.value) return
+  const item = quarantine.value.find(entry => entry.failed_job_id === job.id)
+  if (!item) return
+  try {
+    await releaseQuarantine(activeConn.value.id, item.id)
+    await loadQuarantine()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to release quarantine item'))
+  }
+}
+
+async function emitCurrentAlerts() {
+  if (!activeConn.value || queueAlerts.value.length === 0) return
+  try {
+    await emitQueueAlerts(activeConn.value.id, {
+      queue: selectedQueue.value,
+      prefix: prefix.value,
+      alerts: queueAlerts.value,
+    })
+    await loadQueueAudit()
+    toast.success('Queue alerts sent')
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to send queue alerts'))
+  }
+}
+
+async function runAgentCommand(command: string) {
+  if (!activeConn.value) return
+  try {
+    await runLaravelAgent(activeConn.value.id, { command, queue: selectedQueue.value })
+  } catch (err) {
+    toast.error(errorMessage(err, 'Laravel agent command failed'))
+  } finally {
+    await loadQueueAudit()
+  }
+}
+
+function recordTimelineSample() {
+  const sample: QueueTimelineSample = {
+    at: new Date().toLocaleTimeString(),
+    ready: queueTotals.value.ready,
+    delayed: queueTotals.value.delayed,
+    reserved: queueTotals.value.reserved,
+    failed: failedJobs.value.length,
+    stuck: stuckJobs.value.length,
+  }
+  const last = timeline.value[timeline.value.length - 1]
+  if (last && last.ready === sample.ready && last.delayed === sample.delayed && last.reserved === sample.reserved && last.failed === sample.failed && last.stuck === sample.stuck) {
+    timeline.value = [...timeline.value.slice(0, -1), sample]
+    return
+  }
+  timeline.value = [...timeline.value, sample].slice(-24)
+}
+
+function timelineWidth(value: number) {
+  return `${Math.max(2, Math.round((value / maxTimelineTotal.value) * 100))}%`
+}
+
+async function exportVisibleJobs() {
+  const payload = {
+    exported_at: new Date().toISOString(),
+    redis_connection: activeConn.value?.name || null,
+    redis_db: selectedDb.value,
+    prefix: prefix.value,
+    queue: selectedQueue.value,
+    state: activeState.value,
+    jobs: activeState.value === 'failed' ? filteredFailedJobs.value : filteredJobs.value,
+  }
+  await exportJson(`laravel-queue-${selectedQueue.value}-${activeState.value}.json`, payload)
+}
+
+async function exportSelectedJobs() {
+  const payload = {
+    exported_at: new Date().toISOString(),
+    redis_connection: activeConn.value?.name || null,
+    redis_db: selectedDb.value,
+    prefix: prefix.value,
+    queue: selectedQueue.value,
+    state: activeState.value,
+    jobs: activeState.value === 'failed' ? selectedFailedJobs.value : selectedJobs.value,
+  }
+  await exportJson(`laravel-queue-${selectedQueue.value}-selected.json`, payload)
+}
+
+async function exportJson(filename: string, payload: unknown) {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename.replace(/[^a-z0-9._-]+/gi, '-').toLowerCase()
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+  toast.success('JSON exported')
+}
+
+async function copyPayload(job: LaravelQueueJob | null) {
+  if (!job) return
+  await navigator.clipboard.writeText(formatPayload(job))
+  toast.success('Payload copied')
+}
+
+async function copyFailedPayload(job: LaravelFailedJob | null) {
+  if (!job) return
+  await navigator.clipboard.writeText(formatFailedPayload(job))
+  toast.success('Failed job payload copied')
+}
+
+async function removeJob(job: LaravelQueueJob | null) {
+  if (!activeConn.value || !job) return
+  const ok = await confirmAction('delete', `Delete this ${job.state} job from "${job.queue}"?`, 'Delete Queue Job')
+  if (!ok) return
+  try {
+    await deleteJob(activeConn.value.id, { queue: selectedQueue.value, prefix: prefix.value, db: selectedDb.value, state: job.state, raw: job.raw })
+    toast.success('Job deleted')
+    await loadQueues()
+    await loadQueueAudit()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to delete job'))
+  }
+}
+
+function toggleJobSelection(job: LaravelQueueJob, checked: boolean) {
+  const next = new Set(selectedJobIds.value)
+  if (checked) next.add(job.id)
+  else next.delete(job.id)
+  selectedJobIds.value = next
+}
+
+function toggleAllVisibleJobs(checked: boolean) {
+  const next = new Set(selectedJobIds.value)
+  for (const job of filteredJobs.value) {
+    if (checked) next.add(job.id)
+    else next.delete(job.id)
+  }
+  selectedJobIds.value = next
+}
+
+function toggleFailedSelection(job: LaravelFailedJob, checked: boolean) {
+  const next = new Set(selectedFailedJobIds.value)
+  if (checked) next.add(job.id)
+  else next.delete(job.id)
+  selectedFailedJobIds.value = next
+}
+
+function toggleAllVisibleFailed(checked: boolean) {
+  const next = new Set(selectedFailedJobIds.value)
+  for (const job of filteredFailedJobs.value) {
+    if (checked) next.add(job.id)
+    else next.delete(job.id)
+  }
+  selectedFailedJobIds.value = next
+}
+
+async function bulkDeleteJobs() {
+  if (!activeConn.value || selectedJobs.value.length === 0) return
+  const ok = await confirmAction('delete', `Delete ${selectedJobs.value.length} selected queue job${selectedJobs.value.length === 1 ? '' : 's'}?`, 'Delete Selected Jobs')
+  if (!ok) return
+  try {
+    await Promise.all(selectedJobs.value.map(job =>
+      deleteJob(activeConn.value!.id, { queue: selectedQueue.value, prefix: prefix.value, db: selectedDb.value, state: job.state, raw: job.raw }),
+    ))
+    toast.success('Selected jobs deleted')
+    selectedJobIds.value = new Set()
+    await loadQueues()
+    await loadQueueAudit()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to delete selected jobs'))
+  }
+}
+
+async function bulkRequeueJobs() {
+  if (!activeConn.value || selectedJobs.value.length === 0) return
+  if (!canAction('retry')) {
+    toast.error('Retry/requeue is disabled by feature flags')
+    return
+  }
+  const movable = selectedJobs.value.filter(job => job.state !== 'ready')
+  if (movable.length === 0) {
+    toast.error('Only delayed or reserved jobs can be requeued')
+    return
+  }
+  const ok = await confirmAction('retry', `Requeue ${movable.length} delayed/reserved job${movable.length === 1 ? '' : 's'}?`, 'Requeue Selected Jobs')
+  if (!ok) return
+  try {
+    await Promise.all(movable.map(job =>
+      requeueJob(activeConn.value!.id, { queue: selectedQueue.value, prefix: prefix.value, db: selectedDb.value, state: job.state, raw: job.raw }),
+    ))
+    toast.success('Selected jobs requeued')
+    selectedJobIds.value = new Set()
+    await loadQueues()
+    await loadQueueAudit()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to requeue selected jobs'))
+  }
+}
+
+async function requeueSelectedJob(job: LaravelQueueJob | null) {
+  if (!activeConn.value || !job) return
+  const ok = await confirmAction('retry', `Move this ${job.state} job back to the ready queue?`, 'Requeue Job')
+  if (!ok) return
+  try {
+    await requeueJob(activeConn.value.id, { queue: selectedQueue.value, prefix: prefix.value, db: selectedDb.value, state: job.state, raw: job.raw })
+    toast.success('Job requeued')
+    await loadQueues()
+    await loadQueueAudit()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to requeue job'))
+  }
+}
+
+async function clearSelectedQueue() {
+  if (!activeConn.value || !selectedQueue.value) return
+  const ok = await confirmAction('clear', `Clear all ready, delayed, reserved, and notify keys for "${selectedQueue.value}"?`, 'Clear Laravel Queue')
+  if (!ok) return
+  try {
+    await clearQueue(activeConn.value.id, { queue: selectedQueue.value, prefix: prefix.value, db: selectedDb.value, state: 'all' })
+    toast.success('Queue cleared')
+    await loadQueues()
+    await loadQueueAudit()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to clear queue'))
+  }
+}
+
+async function retrySelectedFailedJob(job: LaravelFailedJob | null, deleteAfter: boolean, queueOverride = '') {
+  if (!activeConn.value || !failedConnId.value || !job) return
+  if (deleteAfter && !canAction('delete')) {
+    toast.error('Delete after retry is disabled by feature flags')
+    return
+  }
+  const action = detailTab.value === 'payload' ? 'editedReplay' : 'retry'
+  const payload = editedFailedPayload.value.trim() || job.raw_payload
+  if (!isValidJson(payload)) {
+    toast.error('Edited payload must be valid JSON')
+    return
+  }
+  const targetQueue = queueOverride.trim() || job.queue || selectedQueue.value
+  const ok = await confirmAction(action, `Retry failed job #${job.id} into "${targetQueue}"?`, 'Retry Failed Job')
+  if (!ok) return
+  try {
+    await retryFailedJob(failedConnId.value, {
+      id: job.id,
+      redis_conn_id: activeConn.value.id,
+      redis_db: selectedDb.value,
+      prefix: prefix.value,
+      queue: targetQueue,
+      payload,
+      delete_after: deleteAfter,
+      payload_edited: payload !== job.raw_payload,
+    })
+    toast.success(deleteAfter ? 'Failed job retried and deleted' : 'Failed job retried')
+    await loadQueues()
+    await loadFailedJobs()
+    await loadQueueAudit()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to retry failed job'))
+  }
+}
+
+async function removeFailedJob(job: LaravelFailedJob | null) {
+  if (!failedConnId.value || !job) return
+  const ok = await confirmAction('delete', `Delete failed job #${job.id}?`, 'Delete Failed Job')
+  if (!ok) return
+  try {
+    await deleteFailedJob(failedConnId.value, job.id, activeConn.value?.id)
+    toast.success('Failed job deleted')
+    await loadFailedJobs()
+    await loadQueueAudit()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to delete failed job'))
+  }
+}
+
+async function bulkRetryFailed(deleteAfter: boolean) {
+  if (!activeConn.value || !failedConnId.value || selectedFailedJobs.value.length === 0) return
+  if (deleteAfter && !canAction('delete')) {
+    toast.error('Delete after retry is disabled by feature flags')
+    return
+  }
+  const ok = await confirmAction('retry', `Retry ${selectedFailedJobs.value.length} selected failed job${selectedFailedJobs.value.length === 1 ? '' : 's'}?`, 'Retry Selected Failed Jobs')
+  if (!ok) return
+  try {
+    await Promise.all(selectedFailedJobs.value.map(job =>
+      retryFailedJob(failedConnId.value!, {
+        id: job.id,
+        redis_conn_id: activeConn.value!.id,
+        redis_db: selectedDb.value,
+        prefix: prefix.value,
+        queue: job.queue || selectedQueue.value,
+        payload: job.raw_payload,
+        delete_after: deleteAfter,
+        payload_edited: false,
+      }),
+    ))
+    toast.success(deleteAfter ? 'Selected failed jobs retried and deleted' : 'Selected failed jobs retried')
+    selectedFailedJobIds.value = new Set()
+    await loadQueues()
+    await loadFailedJobs()
+    await loadQueueAudit()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to retry selected failed jobs'))
+  }
+}
+
+async function bulkDeleteFailed() {
+  if (!failedConnId.value || selectedFailedJobs.value.length === 0) return
+  const ok = await confirmAction('delete', `Delete ${selectedFailedJobs.value.length} selected failed job row${selectedFailedJobs.value.length === 1 ? '' : 's'}?`, 'Delete Selected Failed Jobs')
+  if (!ok) return
+  try {
+    await Promise.all(selectedFailedJobs.value.map(job =>
+      deleteFailedJob(failedConnId.value!, job.id, activeConn.value?.id),
+    ))
+    toast.success('Selected failed jobs deleted')
+    selectedFailedJobIds.value = new Set()
+    await loadFailedJobs()
+    await loadQueueAudit()
+  } catch (err) {
+    toast.error(errorMessage(err, 'Failed to delete selected failed jobs'))
+  }
+}
+
+async function refreshCurrentView() {
+  await loadQueues()
+  await loadHorizon()
+  if (activeState.value === 'failed' && failedConnId.value) await loadFailedJobs()
+}
+
+function stopAutoRefresh() {
+  if (refreshTimer != null) {
+    window.clearInterval(refreshTimer)
+    refreshTimer = null
+  }
+}
+
+function loadProfiles() {
+  try {
+    profiles.value = JSON.parse(localStorage.getItem('laravel_queue_profiles') || '[]')
+  } catch {
+    profiles.value = []
+  }
+}
+
+function persistProfiles() {
+  localStorage.setItem('laravel_queue_profiles', JSON.stringify(profiles.value))
+}
+
+function saveProfile() {
+  const name = profileName.value.trim() || `${activeConn.value?.name || 'Redis'} / ${selectedQueue.value}`
+  const profile: QueueProfile = {
+    name,
+    redisConnId: activeConn.value?.id ?? null,
+    redisDb: selectedDb.value,
+    prefix: prefix.value,
+    queue: selectedQueue.value,
+    failedConnId: failedConnId.value,
+    retryAfter: Number(retryAfter.value || 90),
+  }
+  const existing = profiles.value.findIndex(item => item.name === name)
+  if (existing >= 0) profiles.value[existing] = profile
+  else profiles.value.push(profile)
+  profiles.value.sort((a, b) => a.name.localeCompare(b.name))
+  selectedProfile.value = name
+  profileName.value = ''
+  persistProfiles()
+  toast.success('Queue profile saved')
+}
+
+async function applyProfile(name: string) {
+  const profile = profiles.value.find(item => item.name === name)
+  if (!profile) return
+  if (profile.redisConnId && profile.redisConnId !== activeConn.value?.id) {
+    pendingProfile.value = profile
+    emit('set-conn', profile.redisConnId)
+    return
+  }
+  selectedDb.value = profile.redisDb
+  prefix.value = profile.prefix
+  selectedQueue.value = profile.queue
+  failedConnId.value = profile.failedConnId
+  retryAfter.value = profile.retryAfter
+  selectedJobIds.value = new Set()
+  selectedFailedJobIds.value = new Set()
+  await loadQueues()
+  if (failedConnId.value) await loadFailedJobs()
+}
+
+function deleteProfile() {
+  if (!selectedProfile.value) return
+  profiles.value = profiles.value.filter(item => item.name !== selectedProfile.value)
+  selectedProfile.value = ''
+  persistProfiles()
+  toast.success('Queue profile deleted')
+}
+
+function errorMessage(err: unknown, fallback: string) {
+  const message = (err as { response?: { data?: { error?: string } } })?.response?.data?.error
+  return message ? `${fallback}: ${message}` : fallback
+}
+</script>
+
+<template>
+  <div class="lq-view">
+    <section v-if="!isRedis" class="page-panel lq-empty">
+      <div class="lq-empty__title">No Redis connection selected</div>
+      <div v-if="redisConnections.length" class="lq-picker">
+        <label class="form-label">Redis Connection</label>
+        <select class="base-input" @change="selectRedisConnection(($event.target as HTMLSelectElement).value)">
+          <option value="">Select Redis connection</option>
+          <option v-for="conn in redisConnections" :key="conn.id" :value="conn.id">
+            {{ conn.name }} - {{ conn.host }}:{{ conn.port }}
+          </option>
+        </select>
+      </div>
+      <div v-else class="lq-muted">Create a Redis connection first.</div>
+    </section>
+
+    <template v-else>
+      <aside class="lq-sidebar">
+        <div class="lq-panel-header">
+          <span>{{ activeConn?.name }}</span>
+          <span class="lq-driver">RD</span>
+        </div>
+
+        <div class="lq-controls">
+          <div class="form-group">
+            <label class="form-label">Profile</label>
+            <div class="lq-profile-row">
+              <select v-model="selectedProfile" class="base-input" @change="applyProfile(selectedProfile)">
+                <option value="">Select profile</option>
+                <option v-for="profile in profiles" :key="profile.name" :value="profile.name">{{ profile.name }}</option>
+              </select>
+              <button class="base-btn base-btn--ghost base-btn--sm" :disabled="!selectedProfile" @click="deleteProfile">Delete</button>
+            </div>
+          </div>
+          <div class="lq-profile-row">
+            <input v-model="profileName" class="base-input" placeholder="Profile name" @keydown.enter="saveProfile" />
+            <button class="base-btn base-btn--primary base-btn--sm" @click="saveProfile">Save</button>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Redis DB</label>
+            <select v-model.number="selectedDb" class="base-input">
+              <option v-for="db in redisDbIndexes" :key="db" :value="db">DB {{ db }}</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label">Queue Prefix</label>
+            <input v-model="prefix" class="base-input" placeholder="queues" @keydown.enter="loadQueues" />
+          </div>
+          <button class="base-btn base-btn--ghost base-btn--sm" :disabled="loadingQueues" @click="loadQueues">Refresh</button>
+        </div>
+
+        <div class="lq-queue-list">
+          <button
+            v-for="queue in queues"
+            :key="queue.name"
+            class="lq-queue"
+            :class="{ 'is-active': selectedQueue === queue.name }"
+            @click="selectedQueue = queue.name"
+          >
+            <span class="lq-queue__name">{{ queue.name }}</span>
+            <span class="lq-queue__meta">{{ queue.ready }} ready / {{ queue.delayed }} delayed / {{ queue.reserved }} reserved</span>
+          </button>
+          <div v-if="!loadingQueues && queues.length === 0" class="lq-muted">No Laravel queues found.</div>
+        </div>
+      </aside>
+
+      <main class="lq-main">
+        <div class="lq-toolbar">
+          <div class="lq-toolbar__info">
+            <span class="lq-title">Laravel Queue</span>
+            <span class="lq-meta">{{ prefix }}:{{ selectedQueue }}</span>
+          </div>
+          <div class="lq-toolbar__actions">
+            <label class="lq-auto">
+              <input v-model="autoRefresh" type="checkbox" />
+              <span>Auto</span>
+            </label>
+            <select v-model.number="refreshSeconds" class="base-input lq-refresh-select" :disabled="!autoRefresh">
+              <option :value="5">5s</option>
+              <option :value="10">10s</option>
+              <option :value="30">30s</option>
+            </select>
+            <span v-if="selectedSummary" class="lq-chip">{{ selectedSummary.ready }} ready</span>
+            <span v-if="selectedSummary" class="lq-chip">{{ selectedSummary.delayed }} delayed</span>
+            <span v-if="selectedSummary" class="lq-chip">{{ selectedSummary.reserved }} reserved</span>
+            <span class="lq-chip" :class="{ 'lq-chip--danger': stuckJobs.length }">{{ stuckJobs.length }} stuck</span>
+            <span v-if="queueAlerts.length" class="lq-chip lq-chip--danger">{{ queueAlerts.length }} alerts</span>
+            <span v-if="featureFlags.readOnly" class="lq-chip lq-chip--danger">read only</span>
+            <span class="lq-chip">oldest {{ oldestJobAge }}</span>
+            <button class="base-btn base-btn--ghost base-btn--sm" :disabled="loadingJobs" @click="loadJobs">Refresh Jobs</button>
+            <button class="base-btn base-btn--danger base-btn--sm" :disabled="!jobs.length || !canAction('clear')" @click="clearSelectedQueue">Clear Queue</button>
+          </div>
+        </div>
+
+        <div class="lq-healthbar">
+          <span class="lq-health">All queues ready <strong>{{ queueTotals.ready }}</strong></span>
+          <span class="lq-health">Delayed <strong>{{ queueTotals.delayed }}</strong></span>
+          <span class="lq-health">Reserved <strong>{{ queueTotals.reserved }}</strong></span>
+          <span class="lq-health" :class="{ 'is-danger': stuckJobs.length }">Stuck <strong>{{ stuckJobs.length }}</strong></span>
+          <span class="lq-health">Failed <strong>{{ failedJobs.length }}</strong></span>
+          <span v-if="horizon?.detected" class="lq-health">Horizon keys <strong>{{ horizon.key_count }}</strong></span>
+          <span v-if="horizon?.detected" class="lq-health">Supervisors <strong>{{ horizon.supervisors }}</strong></span>
+          <span v-if="horizon?.detected" class="lq-health">Recent <strong>{{ horizon.recent_jobs }}</strong></span>
+          <span v-if="!horizon?.detected" class="lq-health">Horizon <strong>not detected</strong></span>
+        </div>
+
+        <section class="lq-insights">
+          <div class="lq-insight-tabs">
+            <button class="lq-insight-tab" :class="{ active: insightTab === 'health' }" @click="insightTab = 'health'">Health</button>
+            <button class="lq-insight-tab" :class="{ active: insightTab === 'timeline' }" @click="insightTab = 'timeline'">Timeline</button>
+            <button class="lq-insight-tab" :class="{ active: insightTab === 'groups' }" @click="insightTab = 'groups'">Failed Groups</button>
+            <button class="lq-insight-tab" :class="{ active: insightTab === 'patterns' }" @click="insightTab = 'patterns'">Patterns</button>
+            <button class="lq-insight-tab" :class="{ active: insightTab === 'quarantine' }" @click="insightTab = 'quarantine'">Quarantine</button>
+            <button class="lq-insight-tab" :class="{ active: insightTab === 'controls' }" @click="insightTab = 'controls'">Controls</button>
+            <button class="lq-insight-tab" :class="{ active: insightTab === 'settings' }" @click="insightTab = 'settings'">Settings</button>
+            <button class="lq-insight-tab" :class="{ active: insightTab === 'audit' }" @click="insightTab = 'audit'; loadQueueAudit()">Audit</button>
+          </div>
+
+          <div v-if="insightTab === 'health'" class="lq-insight-grid">
+            <div v-if="queueAlerts.length" class="lq-insight is-warning">
+              <div class="lq-insight__title">Notifications</div>
+              <div class="lq-insight__detail">{{ queueAlerts.length }} active rule alert{{ queueAlerts.length === 1 ? '' : 's' }} can be sent to notification rules.</div>
+              <button class="base-btn base-btn--primary base-btn--sm" @click="emitCurrentAlerts">Send Alerts</button>
+            </div>
+            <div v-for="issue in healthIssues" :key="issue.title" class="lq-insight" :class="`is-${issue.level}`">
+              <div class="lq-insight__title">{{ issue.title }}</div>
+              <div class="lq-insight__detail">{{ issue.detail }}</div>
+            </div>
+          </div>
+
+          <div v-else-if="insightTab === 'timeline'" class="lq-timeline">
+            <div v-if="timeline.length === 0" class="lq-muted">Timeline will populate after refreshes.</div>
+            <div v-for="sample in timeline" :key="sample.at" class="lq-timeline-row">
+              <span class="lq-timeline-time">{{ sample.at }}</span>
+              <div class="lq-timeline-bars">
+                <span v-if="sample.ready" class="lq-bar is-ready" :style="{ width: timelineWidth(sample.ready) }">{{ sample.ready }}</span>
+                <span v-if="sample.delayed" class="lq-bar is-delayed" :style="{ width: timelineWidth(sample.delayed) }">{{ sample.delayed }}</span>
+                <span v-if="sample.reserved" class="lq-bar is-reserved" :style="{ width: timelineWidth(sample.reserved) }">{{ sample.reserved }}</span>
+                <span v-if="sample.failed" class="lq-bar is-failed" :style="{ width: timelineWidth(sample.failed) }">{{ sample.failed }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div v-else-if="insightTab === 'groups'" class="lq-groups">
+            <div class="lq-groups__toolbar">
+              <span>Group by</span>
+              <select v-model="failedGroupBy" class="base-input lq-group-select">
+                <option value="job">Job</option>
+                <option value="exception">Exception</option>
+                <option value="queue">Queue</option>
+                <option value="date">Date</option>
+              </select>
+            </div>
+            <div v-if="failedGroups.length === 0" class="lq-muted">Load failed jobs to see groups.</div>
+            <button
+              v-for="group in failedGroups"
+              :key="group.key"
+              class="lq-group"
+              @click="selectedFailedJobId = group.sample.id; activeState = 'failed'"
+            >
+              <span class="lq-group__name">{{ group.key }}</span>
+              <span class="lq-group__meta">{{ group.count }} failed / latest {{ formatDate(group.latest) }}</span>
+            </button>
+          </div>
+
+          <div v-if="insightTab === 'patterns'" class="lq-groups">
+            <div v-if="failedPatterns.length === 0" class="lq-muted">No repeated failed-job patterns detected from loaded rows.</div>
+            <button
+              v-for="pattern in failedPatterns"
+              :key="pattern.key"
+              class="lq-group"
+              @click="selectedFailedJobId = pattern.sample.id; activeState = 'failed'"
+            >
+              <span class="lq-group__name">{{ pattern.key }}</span>
+              <span class="lq-group__meta">{{ pattern.count }} repeats / latest {{ formatDate(pattern.latest) }}</span>
+            </button>
+          </div>
+
+          <div v-if="insightTab === 'quarantine'" class="lq-groups">
+            <div v-if="quarantine.length === 0" class="lq-muted">No failed jobs in quarantine.</div>
+            <button
+              v-for="item in quarantine"
+              :key="item.id"
+              class="lq-group"
+              @click="selectedFailedJobId = item.failed_job_id; activeState = 'failed'"
+            >
+              <span class="lq-group__name">{{ item.job_name || item.uuid || `failed_jobs #${item.failed_job_id}` }}</span>
+              <span class="lq-group__meta">{{ item.queue }} / {{ formatDate(item.created_at) }}</span>
+            </button>
+          </div>
+
+          <div v-if="insightTab === 'controls'" class="lq-ops-grid">
+            <div class="lq-ops-card">
+              <div class="lq-insight__title">Retry Sandbox</div>
+              <div class="lq-insight__detail">Retry selected failed jobs into a non-production queue.</div>
+              <input v-model="sandboxQueue" class="base-input" placeholder="debug" />
+              <button class="base-btn base-btn--primary base-btn--sm" :disabled="!selectedFailedJob || !canAction('retry')" @click="retrySelectedFailedJob(selectedFailedJob, false, sandboxQueue)">Retry current to sandbox</button>
+            </div>
+            <div class="lq-ops-card">
+              <div class="lq-insight__title">Horizon / Worker Control</div>
+              <div class="lq-insight__detail">Laravel command execution is not connected yet. These controls are disabled until a Laravel agent/API is configured.</div>
+              <div class="lq-control-buttons">
+                <button class="base-btn base-btn--ghost base-btn--sm" @click="runAgentCommand('horizon:pause')">Pause</button>
+                <button class="base-btn base-btn--ghost base-btn--sm" @click="runAgentCommand('horizon:continue')">Resume</button>
+                <button class="base-btn base-btn--ghost base-btn--sm" @click="runAgentCommand('horizon:terminate')">Terminate</button>
+                <button class="base-btn base-btn--ghost base-btn--sm" @click="runAgentCommand('queue:retry')">queue:retry</button>
+                <button class="base-btn base-btn--ghost base-btn--sm" @click="runAgentCommand('queue:flush')">queue:flush</button>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="insightTab === 'settings'" class="lq-settings">
+            <div class="lq-settings-card">
+              <div class="lq-insight__title">Feature Flags</div>
+              <label><input v-model="featureFlags.readOnly" type="checkbox" /> Read-only mode</label>
+              <label><input v-model="featureFlags.retry" type="checkbox" /> Enable retry actions</label>
+              <label><input v-model="featureFlags.delete" type="checkbox" /> Enable delete actions</label>
+              <label><input v-model="featureFlags.clear" type="checkbox" /> Enable clear queue</label>
+              <label><input v-model="featureFlags.editedReplay" type="checkbox" /> Enable edited payload replay</label>
+              <label><input v-model="featureFlags.requireConfirm" type="checkbox" /> Require confirmation</label>
+            </div>
+            <div class="lq-settings-card">
+              <div class="lq-insight__title">Queue Rules</div>
+              <label>Ready jobs &gt;<input v-model.number="queueRules.readyMax" class="base-input" type="number" min="0" /></label>
+              <label>Failed jobs &gt;<input v-model.number="queueRules.failedMax" class="base-input" type="number" min="0" /></label>
+              <label>Stuck jobs &gt;<input v-model.number="queueRules.stuckMax" class="base-input" type="number" min="0" /></label>
+              <label>Oldest age minutes &gt;<input v-model.number="queueRules.oldestMinutesMax" class="base-input" type="number" min="0" /></label>
+              <label><input v-model="queueRules.noConsumption" type="checkbox" /> Alert when no consumption is detected</label>
+            </div>
+            <div class="lq-settings-card">
+              <div class="lq-insight__title">Business Context Presets</div>
+              <div class="lq-insight__detail">Comma-separated fields highlighted in Main Data.</div>
+              <textarea v-model="businessFieldsInput" class="base-input lq-small-editor" rows="4" />
+            </div>
+          </div>
+
+          <div v-if="insightTab === 'audit'" class="lq-audit-list">
+            <div v-if="queueAudit.length === 0" class="lq-muted">No Laravel Queue audit entries yet.</div>
+            <div v-for="entry in queueAudit" :key="entry.id" class="lq-audit-row">
+              <span class="lq-audit-action">{{ entry.action }}</span>
+              <span>{{ entry.status }}</span>
+              <span>{{ entry.queue || entry.target_queue || '-' }}</span>
+              <span>{{ entry.failed_job_id || entry.job_uuid || '-' }}</span>
+              <span>{{ entry.username || `user #${entry.user_id}` }}</span>
+              <span>{{ formatDate(entry.created_at) }}</span>
+            </div>
+          </div>
+        </section>
+
+        <div class="lq-filterbar">
+          <input v-model="search" class="base-input lq-search" placeholder="Search UUID, class, handler, or payload" />
+          <label class="lq-retry-after">
+            <span>Retry after</span>
+            <input v-model.number="retryAfter" class="base-input" type="number" min="1" />
+            <span>seconds</span>
+          </label>
+          <select v-model.number="failedConnId" class="base-input lq-failed-select" title="SQL connection for failed_jobs">
+            <option :value="null">Failed jobs connection</option>
+            <option v-for="conn in sqlConnections" :key="conn.id" :value="conn.id">{{ conn.name }}</option>
+          </select>
+          <button class="base-btn base-btn--ghost base-btn--sm" :disabled="!failedConnId || loadingFailed" @click="loadFailedJobs">Load Failed</button>
+        </div>
+
+        <div class="lq-tabs">
+          <button class="lq-tab" :class="{ active: activeState === 'all' }" @click="activeState = 'all'">All <span>{{ jobs.length }}</span></button>
+          <button class="lq-tab" :class="{ active: activeState === 'ready' }" @click="activeState = 'ready'">Ready <span>{{ stateCount('ready') }}</span></button>
+          <button class="lq-tab" :class="{ active: activeState === 'delayed' }" @click="activeState = 'delayed'">Delayed <span>{{ stateCount('delayed') }}</span></button>
+          <button class="lq-tab" :class="{ active: activeState === 'reserved' }" @click="activeState = 'reserved'">Reserved <span>{{ stateCount('reserved') }}</span></button>
+          <button class="lq-tab" :class="{ active: activeState === 'failed' }" @click="activeState = 'failed'; loadFailedJobs()">Failed <span>{{ failedJobs.length }}</span></button>
+        </div>
+
+        <div v-if="activeState !== 'failed' && selectedJobIds.size" class="lq-bulkbar">
+          <span>{{ selectedJobIds.size }} selected</span>
+          <button class="base-btn base-btn--ghost base-btn--sm" :disabled="!canAction('retry')" @click="bulkRequeueJobs">Requeue selected</button>
+          <button class="base-btn base-btn--danger base-btn--sm" :disabled="!canAction('delete')" @click="bulkDeleteJobs">Delete selected</button>
+          <button class="base-btn base-btn--ghost base-btn--sm" @click="exportSelectedJobs">Export selected</button>
+        </div>
+
+        <div v-if="activeState === 'failed' && selectedFailedJobIds.size" class="lq-bulkbar">
+          <span>{{ selectedFailedJobIds.size }} failed selected</span>
+          <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('retry')" @click="bulkRetryFailed(false)">Retry selected</button>
+          <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('retry') || !canAction('delete')" @click="bulkRetryFailed(true)">Retry & delete</button>
+          <button class="base-btn base-btn--danger base-btn--sm" :disabled="!canAction('delete')" @click="bulkDeleteFailed">Delete failed</button>
+          <button class="base-btn base-btn--ghost base-btn--sm" @click="quarantineSelectedFailed">Quarantine</button>
+          <button class="base-btn base-btn--ghost base-btn--sm" @click="exportSelectedJobs">Export selected</button>
+        </div>
+
+        <div class="lq-exportbar">
+          <button class="base-btn base-btn--ghost base-btn--sm" :disabled="activeState === 'failed' ? !filteredFailedJobs.length : !filteredJobs.length" @click="exportVisibleJobs">
+            Export visible JSON
+          </button>
+        </div>
+
+        <div class="lq-content">
+          <section v-if="activeState !== 'failed'" class="lq-jobs">
+            <table class="lq-table">
+              <thead>
+                <tr>
+                  <th class="lq-select-col">
+                    <input type="checkbox" :checked="allVisibleJobsSelected" @change="toggleAllVisibleJobs(($event.target as HTMLInputElement).checked)" />
+                  </th>
+                  <th>State</th>
+                  <th>Job</th>
+                  <th>Attempts</th>
+                  <th>Available At</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="job in filteredJobs"
+                  :key="job.id"
+                  :class="{ 'is-active': selectedJob?.id === job.id, 'is-stuck': isStuckJob(job) }"
+                  @click="selectedJobId = job.id"
+                >
+                  <td class="lq-select-col" @click.stop>
+                    <input type="checkbox" :checked="selectedJobIds.has(job.id)" @change="toggleJobSelection(job, ($event.target as HTMLInputElement).checked)" />
+                  </td>
+                  <td>
+                    <span class="lq-state" :data-state="job.state">{{ job.state }}</span>
+                    <span v-if="isStuckJob(job)" class="lq-state lq-state--stuck">stuck</span>
+                  </td>
+                  <td>
+                    <div class="lq-job-name">{{ job.display_name || job.command_name || job.job || 'Laravel job' }}</div>
+                    <div class="lq-job-sub">{{ job.uuid || job.id }}</div>
+                  </td>
+                  <td>{{ job.attempts }}</td>
+                  <td>{{ formatDate(job.available_at) }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <div v-if="!loadingJobs && filteredJobs.length === 0" class="lq-empty-inline">No jobs in this state.</div>
+          </section>
+
+          <section v-else class="lq-jobs">
+            <table class="lq-table">
+              <thead>
+                <tr>
+                  <th class="lq-select-col">
+                    <input type="checkbox" :checked="allVisibleFailedJobsSelected" @change="toggleAllVisibleFailed(($event.target as HTMLInputElement).checked)" />
+                  </th>
+                  <th>ID</th>
+                  <th>Queue</th>
+                  <th>Job</th>
+                  <th>Failed At</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="job in filteredFailedJobs"
+                  :key="job.id"
+                  :class="{ 'is-active': selectedFailedJob?.id === job.id }"
+                  @click="selectedFailedJobId = job.id"
+                >
+                  <td class="lq-select-col" @click.stop>
+                    <input type="checkbox" :checked="selectedFailedJobIds.has(job.id)" @change="toggleFailedSelection(job, ($event.target as HTMLInputElement).checked)" />
+                  </td>
+                  <td>{{ job.id }}</td>
+                  <td>{{ job.queue }}</td>
+                  <td>
+                    <div class="lq-job-name">{{ job.payload?.displayName || job.payload?.job || job.uuid || 'Failed job' }}</div>
+                    <div class="lq-job-sub">{{ job.connection }}</div>
+                  </td>
+                  <td>{{ formatDate(job.failed_at) }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <div v-if="!loadingFailed && filteredFailedJobs.length === 0" class="lq-empty-inline">No failed jobs loaded.</div>
+          </section>
+
+          <aside class="lq-detail">
+            <template v-if="activeState !== 'failed' && selectedJob">
+              <div class="lq-detail__head">
+                <div>
+                  <div class="lq-detail__title">{{ selectedJob.display_name || selectedJob.command_name || 'Laravel job' }}</div>
+                  <div class="lq-detail__sub">{{ selectedJob.uuid || selectedJob.id }}</div>
+                </div>
+                <span class="lq-state" :data-state="selectedJob.state">{{ selectedJob.state }}</span>
+              </div>
+              <div class="lq-detail__actions">
+                <button class="base-btn base-btn--ghost base-btn--sm" @click="copyPayload(selectedJob)">Copy Payload</button>
+                <button v-if="selectedJob.state !== 'ready'" class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('retry')" @click="requeueSelectedJob(selectedJob)">Requeue</button>
+                <button class="base-btn base-btn--danger base-btn--sm" :disabled="!canAction('delete')" @click="removeJob(selectedJob)">Delete</button>
+              </div>
+              <div class="lq-detail-tabs">
+                <button class="lq-detail-tab" :class="{ active: detailTab === 'summary' }" @click="detailTab = 'summary'">Summary</button>
+                <button class="lq-detail-tab" :class="{ active: detailTab === 'main' }" @click="detailTab = 'main'">Main Data</button>
+                <button class="lq-detail-tab" :class="{ active: detailTab === 'payload' }" @click="detailTab = 'payload'">Payload</button>
+                <button class="lq-detail-tab" :class="{ active: detailTab === 'command' }" @click="detailTab = 'command'">Command</button>
+              </div>
+              <div v-if="detailTab === 'summary'" class="lq-props">
+                <span>Queue</span><code>{{ selectedJob.queue }}</code>
+                <span>Handler</span><code>{{ selectedJob.job || '-' }}</code>
+                <span>Command</span><code>{{ selectedJob.command_name || '-' }}</code>
+                <span>Attempts</span><code>{{ selectedJob.attempts }}</code>
+                <span>Max Tries</span><code>{{ selectedJob.max_tries || '-' }}</code>
+                <span>Timeout</span><code>{{ selectedJob.timeout ? `${selectedJob.timeout}s` : '-' }}</code>
+                <span>Backoff</span><code>{{ selectedJob.backoff == null ? '-' : JSON.stringify(selectedJob.backoff) }}</code>
+                <span>Available</span><code>{{ formatDate(selectedJob.available_at) }}</code>
+                <span>Age</span><code>{{ selectedJob.score ? ageLabel(selectedJob.score) : '-' }}</code>
+              </div>
+              <pre v-if="detailTab === 'main'" class="lq-payload">{{ mainDataForJob(selectedJob) }}</pre>
+              <pre v-if="detailTab === 'payload'" class="lq-payload">{{ formatPayload(selectedJob) }}</pre>
+              <pre v-if="detailTab === 'command'" class="lq-payload">{{ commandData(selectedJob) || 'No command data found.' }}</pre>
+            </template>
+            <template v-else-if="activeState === 'failed' && selectedFailedJob">
+              <div class="lq-detail__head">
+                <div>
+                  <div class="lq-detail__title">{{ selectedFailedJob.payload?.displayName || selectedFailedJob.payload?.job || 'Failed job' }}</div>
+                  <div class="lq-detail__sub">{{ selectedFailedJob.uuid || `failed_jobs #${selectedFailedJob.id}` }}</div>
+                </div>
+                <span class="lq-state lq-state--failed">failed</span>
+              </div>
+              <div class="lq-detail__actions">
+                <button class="base-btn base-btn--ghost base-btn--sm" @click="copyFailedPayload(selectedFailedJob)">Copy Payload</button>
+                <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('retry')" @click="retrySelectedFailedJob(selectedFailedJob, false)">Retry</button>
+                <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('retry') || !canAction('delete')" @click="retrySelectedFailedJob(selectedFailedJob, true)">Retry & Delete</button>
+                <button class="base-btn base-btn--ghost base-btn--sm" @click="quarantineFailed(selectedFailedJob)">Quarantine</button>
+                <button v-if="quarantinedFailedJobIds.has(selectedFailedJob.id)" class="base-btn base-btn--ghost base-btn--sm" @click="removeFromQuarantine(selectedFailedJob)">Unquarantine</button>
+                <button class="base-btn base-btn--danger base-btn--sm" :disabled="!canAction('delete')" @click="removeFailedJob(selectedFailedJob)">Delete Failed</button>
+              </div>
+              <div class="lq-detail-tabs">
+                <button class="lq-detail-tab" :class="{ active: detailTab === 'summary' }" @click="detailTab = 'summary'">Summary</button>
+                <button class="lq-detail-tab" :class="{ active: detailTab === 'main' }" @click="detailTab = 'main'">Main Data</button>
+                <button class="lq-detail-tab" :class="{ active: detailTab === 'payload' }" @click="detailTab = 'payload'">Payload</button>
+                <button class="lq-detail-tab" :class="{ active: detailTab === 'command' }" @click="detailTab = 'command'">Command</button>
+                <button class="lq-detail-tab" :class="{ active: detailTab === 'exception' }" @click="detailTab = 'exception'">Exception</button>
+              </div>
+              <div v-if="detailTab === 'summary'" class="lq-props">
+                <span>ID</span><code>{{ selectedFailedJob.id }}</code>
+                <span>Connection</span><code>{{ selectedFailedJob.connection }}</code>
+                <span>Queue</span><code>{{ selectedFailedJob.queue }}</code>
+                <span>Failed At</span><code>{{ formatDate(selectedFailedJob.failed_at) }}</code>
+              </div>
+              <pre v-if="detailTab === 'main'" class="lq-payload">{{ mainDataForFailedJob(selectedFailedJob) }}</pre>
+              <div v-if="detailTab === 'payload'" class="lq-editor-block">
+                <textarea v-model="editedFailedPayload" class="base-input lq-payload-editor" rows="14" />
+                <div class="lq-editor-actions">
+                  <button class="base-btn base-btn--ghost base-btn--sm" @click="editedFailedPayload = formatFailedPayload(selectedFailedJob)">Reset</button>
+                  <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('editedReplay')" @click="retrySelectedFailedJob(selectedFailedJob, false)">Retry Edited</button>
+                  <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('editedReplay') || !canAction('delete')" @click="retrySelectedFailedJob(selectedFailedJob, true)">Retry Edited & Delete</button>
+                </div>
+              </div>
+              <pre v-if="detailTab === 'command'" class="lq-payload">{{ failedCommandData(selectedFailedJob) || 'No command data found.' }}</pre>
+              <pre v-if="detailTab === 'exception'" class="lq-exception">{{ selectedFailedJob.exception }}</pre>
+            </template>
+            <div v-else class="lq-muted">Select a job to inspect the payload.</div>
+          </aside>
+        </div>
+      </main>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.lq-view {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg-body);
+  border-top: 1px solid var(--border);
+}
+
+.lq-empty {
+  grid-column: 1 / -1;
+  margin: 18px;
+  padding: 18px;
+}
+
+.lq-empty__title,
+.lq-title {
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.lq-picker {
+  max-width: 360px;
+  margin-top: 12px;
+}
+
+.lq-sidebar {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  border-right: 1px solid var(--border);
+  background: var(--bg-surface);
+  overflow: hidden;
+  box-shadow: 2px 0 12px rgba(0,0,0,.03);
+}
+
+.lq-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.lq-driver {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 18px;
+  border-radius: 4px;
+  background: #c6302b;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.lq-controls {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.lq-profile-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.lq-queue-list {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  padding: 4px 0;
+}
+
+.lq-queue {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 8px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.lq-queue:hover,
+.lq-queue.is-active {
+  background: color-mix(in srgb, var(--brand) 11%, var(--bg-surface));
+}
+
+.lq-queue__name {
+  font-size: 12.5px;
+  font-weight: 700;
+}
+
+.lq-queue__meta,
+.lq-meta,
+.lq-muted,
+.lq-detail__sub,
+.lq-job-sub {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.lq-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg-body);
+}
+
+.lq-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 48px;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+
+.lq-toolbar__info,
+.lq-toolbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.lq-chip {
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.lq-chip--danger {
+  color: var(--danger);
+  background: var(--danger-bg);
+  border-color: color-mix(in srgb, var(--danger) 35%, var(--border));
+}
+
+.lq-auto {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.lq-refresh-select {
+  width: 68px;
+  padding: 5px 8px;
+  font-size: 12px;
+}
+
+.lq-healthbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+
+.lq-health {
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--bg-body);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.lq-health strong {
+  color: var(--text-primary);
+}
+
+.lq-health.is-danger {
+  color: var(--danger);
+  background: var(--danger-bg);
+}
+
+.lq-insights {
+  display: grid;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-body);
+}
+
+.lq-insight-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.lq-insight-tab {
+  height: 28px;
+  padding: 0 10px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  cursor: pointer;
+}
+
+.lq-insight-tab.active {
+  border-bottom-color: var(--brand);
+  color: var(--text-primary);
+}
+
+.lq-insight-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.lq-insight {
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-surface);
+}
+
+.lq-insight.is-danger {
+  border-color: color-mix(in srgb, var(--danger) 35%, var(--border));
+  background: var(--danger-bg);
+}
+
+.lq-insight.is-warning {
+  border-color: color-mix(in srgb, var(--warning) 35%, var(--border));
+  background: var(--warning-bg);
+}
+
+.lq-insight.is-ok {
+  border-color: color-mix(in srgb, var(--success) 28%, var(--border));
+  background: var(--success-bg);
+}
+
+.lq-insight__title {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.lq-insight__detail {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
+.lq-timeline {
+  display: grid;
+  gap: 7px;
+}
+
+.lq-timeline-row {
+  display: grid;
+  grid-template-columns: 72px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+}
+
+.lq-timeline-time {
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.lq-timeline-bars {
+  display: flex;
+  gap: 4px;
+  min-width: 0;
+}
+
+.lq-bar {
+  min-width: 20px;
+  height: 18px;
+  padding: 2px 5px;
+  border-radius: 4px;
+  color: #fff;
+  font-family: var(--mono);
+  font-size: 10px;
+  line-height: 14px;
+}
+
+.lq-bar.is-ready { background: var(--success); }
+.lq-bar.is-delayed { background: var(--warning); }
+.lq-bar.is-reserved { background: var(--brand); }
+.lq-bar.is-failed { background: var(--danger); }
+
+.lq-groups {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.lq-groups__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  grid-column: 1 / -1;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.lq-group-select {
+  max-width: 150px;
+  padding: 5px 8px;
+  font-size: 12px;
+}
+
+.lq-group {
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-surface);
+  text-align: left;
+  cursor: pointer;
+}
+
+.lq-group:hover {
+  border-color: color-mix(in srgb, var(--brand) 36%, var(--border));
+  background: color-mix(in srgb, var(--brand) 8%, var(--bg-surface));
+}
+
+.lq-group__name {
+  display: block;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lq-group__meta {
+  display: block;
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.lq-ops-grid,
+.lq-settings {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.lq-ops-card,
+.lq-settings-card {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-surface);
+}
+
+.lq-settings-card label {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.lq-settings-card label:has(.base-input) {
+  grid-template-columns: minmax(130px, auto) minmax(0, 1fr);
+}
+
+.lq-control-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.lq-small-editor {
+  min-height: 76px;
+  font-family: var(--mono);
+  font-size: 12px;
+  resize: vertical;
+}
+
+.lq-audit-list {
+  display: grid;
+  gap: 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-surface);
+}
+
+.lq-audit-row {
+  display: grid;
+  grid-template-columns: 120px 80px 1fr 110px 120px 150px;
+  gap: 10px;
+  align-items: center;
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+
+.lq-audit-row:last-child {
+  border-bottom: 0;
+}
+
+.lq-audit-action {
+  color: var(--text-primary);
+  font-family: var(--mono);
+  font-weight: 700;
+}
+
+.lq-filterbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+
+.lq-search {
+  max-width: 460px;
+}
+
+.lq-retry-after {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.lq-retry-after input {
+  width: 78px;
+  padding: 6px 8px;
+}
+
+.lq-failed-select {
+  max-width: 240px;
+}
+
+.lq-tabs {
+  display: flex;
+  min-height: 32px;
+  padding: 0 4px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elevated);
+}
+
+.lq-bulkbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 38px;
+  padding: 7px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.lq-exportbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 7px 14px 0;
+}
+
+.lq-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 10px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  cursor: pointer;
+}
+
+.lq-tab.active {
+  border-bottom-color: var(--brand);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+}
+
+.lq-tab span {
+  color: var(--brand);
+  font-weight: 700;
+}
+
+.lq-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
+  gap: 14px;
+  min-height: 0;
+  flex: 1;
+  padding: 14px;
+  overflow: hidden;
+}
+
+.lq-jobs,
+.lq-detail {
+  min-height: 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-surface);
+}
+
+.lq-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--mono);
+  font-size: 12.5px;
+}
+
+.lq-select-col {
+  width: 34px;
+  min-width: 34px;
+  text-align: center;
+}
+
+.lq-select-col input {
+  display: inline-block;
+  margin: 0;
+}
+
+.lq-table th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+.lq-table td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-primary);
+  vertical-align: middle;
+}
+
+.lq-table tbody tr {
+  cursor: pointer;
+}
+
+.lq-table tbody tr:hover td,
+.lq-table tbody tr.is-active td {
+  background: color-mix(in srgb, var(--brand) 9%, var(--bg-surface));
+}
+
+.lq-table tbody tr.is-stuck td {
+  background: color-mix(in srgb, var(--danger) 7%, var(--bg-surface));
+}
+
+.lq-state {
+  display: inline-flex;
+  padding: 2px 7px;
+  border-radius: 5px;
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.lq-state[data-state="ready"] { color: var(--success); background: var(--success-bg); }
+.lq-state[data-state="delayed"] { color: var(--warning); background: var(--warning-bg); }
+.lq-state[data-state="reserved"] { color: var(--brand); background: var(--brand-dim); }
+
+.lq-state--stuck {
+  margin-left: 6px;
+  color: var(--danger);
+  background: var(--danger-bg);
+}
+
+.lq-state--failed {
+  color: var(--danger);
+  background: var(--danger-bg);
+}
+
+.lq-job-name {
+  max-width: 420px;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--mono);
+  font-size: 12.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lq-empty-inline {
+  padding: 24px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.lq-detail {
+  padding: 14px;
+}
+
+.lq-detail__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.lq-detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.lq-detail-tabs {
+  display: flex;
+  gap: 0;
+  margin: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.lq-detail-tab {
+  height: 30px;
+  padding: 0 10px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  cursor: pointer;
+}
+
+.lq-detail-tab.active {
+  border-bottom-color: var(--brand);
+  color: var(--text-primary);
+}
+
+.lq-detail__title {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.lq-props {
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr);
+  gap: 8px 10px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+}
+
+.lq-props span {
+  color: var(--text-muted);
+}
+
+.lq-props code {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lq-payload {
+  margin: 12px 0 0;
+  min-height: 260px;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg-body);
+  color: var(--text-primary);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.lq-exception {
+  margin: 12px 0 0;
+  max-height: 240px;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--danger) 28%, var(--border));
+  border-radius: var(--r-sm);
+  background: var(--danger-bg);
+  color: var(--danger);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.lq-editor-block {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.lq-payload-editor {
+  min-height: 260px;
+  overflow: auto;
+  padding: 12px;
+  background: var(--bg-body);
+  color: var(--text-primary);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.lq-editor-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+@media (max-width: 1000px) {
+  .lq-view,
+  .lq-content {
+    grid-template-columns: 1fr;
+  }
+
+  .lq-insight-grid,
+  .lq-groups,
+  .lq-ops-grid,
+  .lq-settings,
+  .lq-audit-row {
+    grid-template-columns: 1fr;
+  }
+
+  .lq-sidebar {
+    min-height: 320px;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .lq-toolbar,
+  .lq-filterbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+</style>

--- a/web/src/views/RedisView.vue
+++ b/web/src/views/RedisView.vue
@@ -1051,7 +1051,7 @@ function quoteCommandArg(value: string) {
 
 .redis-tabbody {
   min-height: 0;
-  padding: 0;
+  padding: 14px;
   overflow: auto;
 }
 
@@ -1066,7 +1066,8 @@ function quoteCommandArg(value: string) {
   gap: 16px;
   min-height: 48px;
   padding: 12px 18px;
-  border-bottom: 1px solid var(--border);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
   background: var(--bg-surface);
   flex-shrink: 0;
 }
@@ -1074,7 +1075,9 @@ function quoteCommandArg(value: string) {
 .redis-data-toolbar {
   min-height: 36px;
   padding: 6px 18px;
-  border-bottom: 1px solid var(--border);
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
   background: var(--bg-surface);
   flex-shrink: 0;
 }
@@ -1091,7 +1094,11 @@ function quoteCommandArg(value: string) {
 
 .redis-table-wrap {
   min-height: 0;
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
   overflow: auto;
+  background: var(--bg-surface);
 }
 
 .redis-data-table {
@@ -1153,7 +1160,7 @@ html[data-theme='light'] .redis-data-table tbody tr:nth-child(even) td {
 }
 
 .redis-empty-work {
-  padding: 28px;
+  padding: 32px;
 }
 
 .redis-edit-split {
@@ -1314,11 +1321,15 @@ html[data-theme='light'] .redis-data-table tbody tr:nth-child(even) td {
   gap: 10px;
 }
 
+.redis-editor__head {
+  padding: 2px 0 12px;
+}
+
 .redis-editor__grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr) 160px 140px;
-  gap: 10px;
-  margin: 12px 0;
+  gap: 12px;
+  margin: 0 0 14px;
 }
 
 .redis-editor__grid--rename {
@@ -1344,6 +1355,7 @@ html[data-theme='light'] .redis-data-table tbody tr:nth-child(even) td {
 
 .redis-editor__actions {
   justify-content: flex-end;
+  margin-top: 14px;
 }
 
 .redis-check {
@@ -1362,7 +1374,7 @@ html[data-theme='light'] .redis-data-table tbody tr:nth-child(even) td {
 .redis-console__row {
   display: flex;
   gap: 8px;
-  margin-top: 12px;
+  margin-top: 14px;
 }
 
 .redis-console__input {
@@ -1371,11 +1383,11 @@ html[data-theme='light'] .redis-data-table tbody tr:nth-child(even) td {
 
 .redis-console__result {
   min-height: 120px;
-  margin-top: 12px;
+  margin-top: 14px;
 }
 
 .redis-script-editor {
-  margin-top: 12px;
+  margin-top: 14px;
   min-height: 220px;
 }
 

--- a/web/src/views/SchemaView.vue
+++ b/web/src/views/SchemaView.vue
@@ -19,6 +19,10 @@ const localConnId = ref<number | null>(props.activeConnId ?? null)
 const activeDatabase = ref('')
 const selectedKey = ref('')
 const detailLoading = ref(false)
+const activeConn = computed(() =>
+  localConnId.value ? connections.value.find(c => c.id === localConnId.value) ?? null : null
+)
+const supportsRelationalSchema = computed(() => !!activeConn.value && activeConn.value.driver !== 'redis')
 
 watch(() => props.activeConnId, (id) => {
   if (id != null) localConnId.value = id
@@ -29,7 +33,7 @@ watch(localConnId, async (id) => {
   objectDetail.value = null
   selectedKey.value = ''
   activeDatabase.value = ''
-  if (!id) return
+  if (!id || !supportsRelationalSchema.value) return
   await fetchSchema(id)
   activeDatabase.value = databases.value[0]?.name ?? ''
 }, { immediate: true })
@@ -45,10 +49,6 @@ watch(activeDatabase, async (dbName) => {
     await selectObject({ type: firstItem.type, name: firstItem.name })
   }
 })
-
-const activeConn = computed(() =>
-  localConnId.value ? connections.value.find(c => c.id === localConnId.value) ?? null : null
-)
 
 async function selectObject(payload: { type: string; name: string }) {
   if (!localConnId.value || !activeDatabase.value) return
@@ -128,6 +128,7 @@ const columnRows = computed(() => (objectDetail.value?.columns ?? []).map((colum
         </div>
         <div v-if="loadingSchema" class="schema-explorer__empty">Loading database structure…</div>
         <div v-else-if="!activeConn" class="schema-explorer__empty">Select a connection to inspect database structure.</div>
+        <div v-else-if="!supportsRelationalSchema" class="schema-explorer__empty">Redis does not expose relational schema here. Use the Redis or Laravel Queue page for this connection.</div>
         <div v-else-if="!activeDatabase" class="schema-explorer__empty">Choose a database or schema to load structural objects.</div>
         <SchemaExplorerTree
           v-else


### PR DESCRIPTION
## Summary
  This PR introduces Redis as a first-class connection type alongside the existing
  relational-database support, and ships a Laravel Queue monitoring surface backed
  by Redis. A second pass of the same code fixed several concurrency bugs,
  correctness issues, and UX problems that surfaced during review.
  ### New features
  - **Redis connection type** — `driver: redis` added to `ConnectionInput`/`Connection`;
    connections, status bar, sidebar, and dropdowns all render the Redis badge (`RD`).
  - **Redis Browser** (`RedisView`) — scan keys with cursor pagination, inspect values
    (string / list / hash / set / zset), write/rename/delete/move keys, run raw
    commands, and execute multi-command scripts. Full audit trail.
  - **Laravel Queue monitor** (`LaravelQueueView`) — real-time overview of ready,
    delayed, reserved, failed, and stuck jobs sourced from Redis. Supports per-queue
    profiles, quarantine, bulk retry/delete, Horizon integration, patterns, timeline,
    failed-job groups, ops settings, and audit log.
  - **Operations → Overview dashboard** now renders a Redis-specific card instead of
    returning 502 for Redis connections.
  - **SQL Studio landing page** — when no sessions are open or the active connection is
    Redis, a connection-picker page lists all SQL databases so the user can open one
    in a single click.
  ### Bug fixes — backend
  | File | Bug | Fix |
  |---|---|---|
  | `handlers/pool.go` | `entry.lastUsed` written under read lock → data race | Write `lastUsed` inside a write lock |
  | `handlers/pool.go` | TOCTOU: two goroutines both fail `Ping()`, both call `db.Close()` | Re-check `current == entry` inside write lock before closing |
  | `handlers/notifications.go` | `insertRowReturningID` appended `RETURNING id` for MySQL, which MySQL does not support → syntax error on every insert | Only append `RETURNING id` for PostgreSQL; MySQL/SQLite use 
  `LastInsertId()` |
  | `handlers/notifications.go` | `processPendingNotificationDeliveries` held DB cursor open while making outbound HTTP calls (up to 10 s × 25 rows = 250 s) | Scan all rows into a slice, `rows.Close()`, then process 
  deliveries |
  | `handlers/dashboard.go` | `GET /api/connections/:id/dashboard` returned 502 for Redis connections | Detect `driver = redis` before calling `GetDB`; return `{"driver":"redis"}` immediately |
  | `handlers/laravel_queue.go` | `deleteLaravelFailedJob` used string formatting instead of a parameterised query | Replaced with `db.ExecContext(ctx, "DELETE … WHERE id = ?", id)` |
  | `handlers/laravel_queue.go` | `LaravelQueueFailedJobAction` used `payload.RedisConnID` before validating it | Moved `<= 0` guard to top of case |
  | `handlers/laravel_queue.go` | Missing `rows.Err()` check after iterating `failed_jobs` | Added check after loop |
  | `handlers/laravel_queue_ops.go` | Non-atomic MySQL upsert (SELECT → INSERT → UPDATE) had a TOCTOU race | Replaced with atomic `INSERT … ON DUPLICATE KEY UPDATE` |
  | `db/db.go` | `ConvertQuery` used `+=` in a loop → O(n²) allocations | Replaced with `strings.Builder` + `Grow` pre-allocation |
  | `db/db.go` | `SetConnMaxLifetime(0)` never recycled connections → stale-connection errors | Set to 5 min (PostgreSQL) / 3 min (MySQL) |
  | `db/db.go` | `seedDefaultAdmin` had duplicate INSERT branches and ignored errors | Collapsed to one call with a `fmt.Printf` warning on failure |
  | `main.go` | `startAutoBackup` goroutine had no shutdown signal → leaked on server stop | Added `context.Context`; goroutine exits on `ctx.Done()` |
  ### Performance improvements — frontend
  | File | Issue | Fix |
  |---|---|---|
  | `LaravelQueueView` | `onMounted` / `watch(activeConnId)` made 4 API calls sequentially | `Promise.all([loadQueues(), loadHorizon(), loadQuarantine(), loadQueueAudit()])` |
  | `LaravelQueueView` | Bulk operations (`bulkDelete`, `bulkRequeue`, `bulkRetry`) iterated with sequential `await` | `Promise.all(items.map(...))` |
  | `LaravelQueueView` | `persistOpsSettings` watcher fired on every keystroke | Added 600 ms `debounce` |
  | `LaravelQueueView` | `quarantineSelectedFailed` used sequential loop; partial failures reported as success | `Promise.allSettled` with accurate failure count in toast |
  ### UX fixes
  | File | Issue | Fix |
  |---|---|---|
  | `LaravelQueueView` | Entire page was not scrollable | Added `overflow: hidden` to `.lq-view`; `min-height: 0; overflow: hidden` to `.lq-main` / `.lq-sidebar` |
  | `DataView` | Redis active connection → blank screen with no guidance | Unified landing page with SQL-connection cards; `quickOpen()` sets global active conn and opens session tab in one click |
  | `DataView` | `+ DB` picker listed Redis connections, opening one caused API errors | `filteredConns` derived from `sqlConns` (excludes `driver === 'redis'`) |
  | `DashboardView` | Redis connection card showed raw API error string | Dedicated "Redis key-value store" card body |
  ## Verification
  - [x] `cd server && go test ./...`
  - [x] `cd web && npm run build`
  - [x] Manual UI verification, if applicable
  ## Checklist
  - [x] The change is focused and reviewable.
  - [x] Documentation was updated when behavior or configuration changed.
  - [x] No secrets, local databases, logs, or generated build output are committed.
  - [x] Security and permission impact was considered.
  ## Screenshots
  Add screenshots or video for visible UI changes.