### PR TITLE
fix: fix logo database acronym

### DIFF
--- a/web/src/views/ConnectionsView.vue
+++ b/web/src/views/ConnectionsView.vue
@@ -211,7 +211,11 @@ function parseConnectionURL(raw: string) {
 }
 
 function driverBadge(driver: DbDriver) {
-  return ({ postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD' } as Record<DbDriver, string>)[driver]
+  return ({ postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD' } as Record<DbDriver, string>)[driver] ?? driver.slice(0, 2).toUpperCase()
+}
+
+function driverFullName(driver: DbDriver) {
+  return ({ postgres: 'PostgreSQL', mysql: 'MySQL', mariadb: 'MariaDB', mssql: 'SQL Server', redis: 'Redis' } as Record<DbDriver, string>)[driver] ?? driver
 }
 
 function openConnection(id: number, driver: DbDriver) {
@@ -265,53 +269,61 @@ async function handleDelete(id: number, name: string) {
           No connections yet. Add your first one.
         </div>
 
-        <div v-else style="display:flex;flex-direction:column;gap:8px">
+        <div v-else class="conn-list">
           <div
             v-for="conn in connections"
             :key="conn.id"
             class="conn-row"
           >
-            <div class="conn-badge" :class="`conn-badge--${conn.driver}`" style="width:36px;height:36px;border-radius:var(--r-sm);font-size:12px">
+            <!-- Driver badge -->
+            <div class="conn-badge conn-row__badge" :class="`conn-badge--${conn.driver}`">
               {{ driverBadge(conn.driver) }}
             </div>
-            <div style="flex:1;min-width:0">
-              <div style="font-size:13px;font-weight:600;color:var(--text-primary);display:flex;align-items:center;gap:6px">
-                {{ conn.name }}
-                <span v-if="conn.visibility === 'private'" style="font-size:11px" title="Private">🔒</span>
-                <span v-else style="font-size:11px" title="Shared">🌐</span>
+
+            <!-- Main info -->
+            <div class="conn-row__body">
+              <div class="conn-row__top">
+                <span class="conn-row__name">{{ conn.name }}</span>
+                <span class="conn-row__driver">{{ driverFullName(conn.driver) }}</span>
+                <span class="conn-row__vis" :title="conn.visibility">{{ conn.visibility === 'shared' ? '🌐' : '🔒' }}</span>
               </div>
-              <div style="font-size:11.5px;font-family:var(--mono);color:var(--text-muted);margin-top:2px">
-                {{ conn.username ? `${conn.username}@` : '' }}{{ conn.host }}:{{ conn.port }}/{{ conn.driver === 'redis' ? `db${conn.database || 0}` : conn.database }}
+              <div class="conn-row__host">
+                {{ conn.username ? `${conn.username}@` : '' }}{{ conn.host }}{{ conn.port ? `:${conn.port}` : '' }}{{ (conn.driver === 'redis' ? `/db${conn.database || 0}` : conn.database ? `/${conn.database}` : '') }}
               </div>
-              <div v-if="conn.folder_id" style="font-size:10.5px;color:var(--text-muted);margin-top:2px">
-                📁 {{ folders.find(f => f.id === conn.folder_id)?.name ?? 'Folder' }}
+              <div v-if="conn.folder_id" class="conn-row__folder">
+                {{ folders.find(f => f.id === conn.folder_id)?.name ?? 'Folder' }}
               </div>
             </div>
-            <span class="badge badge--default">{{ conn.driver.toUpperCase() }}</span>
-            <button class="base-btn base-btn--ghost base-btn--sm" @click="openConnection(conn.id, conn.driver)">
-              Open
-            </button>
-            <!-- Quick folder assign -->
-            <select
-              :value="conn.folder_id ?? ''"
-              class="conn-folder-select"
-              title="Move to folder"
-              @change="moveConnection(conn.id, ($event.target as HTMLSelectElement).value ? Number(($event.target as HTMLSelectElement).value) : null)"
-            >
-              <option value="">📂 Unfiled</option>
-              <option v-for="f in folders" :key="f.id" :value="f.id">{{ f.visibility === 'shared' ? '🌐' : '🔒' }} {{ f.name }}</option>
-            </select>
-            <!-- Visibility toggle -->
-            <button class="icon-btn" :title="conn.visibility === 'shared' ? 'Make private' : 'Make shared'"
-              @click="setConnectionVisibility(conn.id, conn.visibility === 'shared' ? 'private' : 'shared').then(() => fetchConnections())">
-              {{ conn.visibility === 'shared' ? '🌐' : '🔒' }}
-            </button>
-            <button class="icon-btn" @click="editConnection(conn.id)" title="Edit">
-              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
-            </button>
-            <button class="icon-btn danger" @click="handleDelete(conn.id, conn.name)" title="Delete">
-              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>
-            </button>
+
+            <!-- Actions -->
+            <div class="conn-row__actions">
+              <button class="base-btn base-btn--primary base-btn--sm" @click="openConnection(conn.id, conn.driver)">
+                Open
+              </button>
+              <select
+                :value="conn.folder_id ?? ''"
+                class="conn-row__folder-sel"
+                title="Move to folder"
+                @change="moveConnection(conn.id, ($event.target as HTMLSelectElement).value ? Number(($event.target as HTMLSelectElement).value) : null)"
+              >
+                <option value="">📂 Unfiled</option>
+                <option v-for="f in folders" :key="f.id" :value="f.id">{{ f.name }}</option>
+              </select>
+              <button
+                class="icon-btn"
+                :title="conn.visibility === 'shared' ? 'Make private' : 'Make shared'"
+                @click="setConnectionVisibility(conn.id, conn.visibility === 'shared' ? 'private' : 'shared').then(() => fetchConnections())"
+              >
+                <svg v-if="conn.visibility === 'shared'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+              </button>
+              <button class="icon-btn" @click="editConnection(conn.id)" title="Edit">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+              </button>
+              <button class="icon-btn danger" @click="handleDelete(conn.id, conn.name)" title="Delete">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>
+              </button>
+            </div>
           </div>
         </div>
       </section>
@@ -541,23 +553,111 @@ async function handleDelete(id: number, name: string) {
   color: var(--text-muted);
 }
 
+.conn-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .conn-row {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 14px 16px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 44%),
-    var(--bg-surface);
+  padding: 12px 14px;
+  background: var(--bg-surface);
   border: 1px solid var(--border);
-  border-radius: 16px;
-  transition: border-color var(--dur), transform var(--dur), box-shadow var(--dur);
+  border-radius: 10px;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .conn-row:hover {
-  border-color: rgba(92, 184, 165, 0.22);
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-sm);
+  border-color: var(--brand);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand) 20%, transparent);
+}
+
+.conn-row__badge {
+  width: 40px;
+  height: 40px;
+  border-radius: 9px;
+  font-size: 12px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.conn-row__body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.conn-row__top {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+
+.conn-row__name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.conn-row__driver {
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: var(--bg-body);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+}
+
+.conn-row__vis {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.conn-row__host {
+  font-size: 11px;
+  font-family: var(--mono);
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.conn-row__folder {
+  font-size: 10.5px;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+.conn-row__folder::before {
+  content: '📁';
+  font-size: 10px;
+}
+
+.conn-row__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.conn-row__folder-sel {
+  height: 28px;
+  padding: 0 6px;
+  font-size: 11.5px;
+  background: var(--bg-body);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  max-width: 130px;
 }
 
 .conn-form {

--- a/web/src/views/LaravelQueueView.vue
+++ b/web/src/views/LaravelQueueView.vue
@@ -124,6 +124,9 @@ const activeConn = computed(() =>
   props.activeConnId != null ? connections.value.find((c) => c.id === props.activeConnId) ?? null : null,
 )
 const isRedis = computed(() => activeConn.value?.driver === 'redis')
+const isSql = computed(() => activeConn.value != null && activeConn.value.driver !== 'redis')
+// When in SQL-only mode, the user picks a Redis conn just for the retry-push step
+const retryRedisConnId = ref<number | null>(null)
 const filteredJobs = computed(() => {
   const query = search.value.trim().toLowerCase()
   return jobs.value.filter((job) => {
@@ -283,15 +286,21 @@ let refreshTimer: number | null = null
 onMounted(async () => {
   loadProfiles()
   if (!connections.value.length) await fetchConnections()
-  if (!isRedis.value && redisConnections.value.length === 1) {
+  // Only auto-switch to the sole Redis connection when no SQL conn is active
+  if (!isRedis.value && !isSql.value && redisConnections.value.length === 1) {
     emit('set-conn', redisConnections.value[0].id)
     return
   }
   selectedDb.value = Number(activeConn.value?.database || 0)
-  failedConnId.value = sqlConnections.value[0]?.id ?? null
   if (isRedis.value) {
+    failedConnId.value = sqlConnections.value[0]?.id ?? null
     await loadOpsSettings()
     await Promise.all([loadQueues(), loadHorizon(), loadQuarantine(), loadQueueAudit()])
+  } else if (isSql.value) {
+    failedConnId.value = props.activeConnId
+    activeState.value = 'failed'
+    await loadOpsSettings()
+    await Promise.all([loadFailedJobs(), loadQuarantine(), loadQueueAudit()])
   }
 })
 
@@ -314,9 +323,15 @@ watch(() => props.activeConnId, async () => {
   selectedFailedJobIds.value = new Set()
   queues.value = []
   jobs.value = []
+  failedJobs.value = []
   if (isRedis.value) {
     await loadOpsSettings()
     await Promise.all([loadQueues(), loadHorizon(), loadQuarantine(), loadQueueAudit()])
+  } else if (isSql.value) {
+    failedConnId.value = props.activeConnId
+    activeState.value = 'failed'
+    await loadOpsSettings()
+    await Promise.all([loadFailedJobs(), loadQuarantine(), loadQueueAudit()])
   }
 })
 
@@ -843,9 +858,11 @@ async function quarantineSelectedFailed() {
 }
 
 async function quarantineFailed(job: LaravelFailedJob | null, notify = true) {
-  if (!activeConn.value || !failedConnId.value || !job) return
+  if (!failedConnId.value || !job) return
+  // In SQL mode, use failedConnId as the primary conn; in Redis mode use the Redis conn
+  const connId = isRedis.value ? activeConn.value!.id : failedConnId.value
   try {
-    await quarantineFailedJob(activeConn.value.id, {
+    await quarantineFailedJob(connId, {
       failed_conn_id: failedConnId.value,
       failed_job_id: job.id,
       uuid: job.uuid,
@@ -864,11 +881,12 @@ async function quarantineFailed(job: LaravelFailedJob | null, notify = true) {
 }
 
 async function removeFromQuarantine(job: LaravelFailedJob) {
-  if (!activeConn.value) return
+  const connId = isRedis.value ? activeConn.value?.id : failedConnId.value
+  if (!connId) return
   const item = quarantine.value.find(entry => entry.failed_job_id === job.id)
   if (!item) return
   try {
-    await releaseQuarantine(activeConn.value.id, item.id)
+    await releaseQuarantine(connId, item.id)
     await loadQuarantine()
   } catch (err) {
     toast.error(errorMessage(err, 'Failed to release quarantine item'))
@@ -1091,7 +1109,12 @@ async function clearSelectedQueue() {
 }
 
 async function retrySelectedFailedJob(job: LaravelFailedJob | null, deleteAfter: boolean, queueOverride = '') {
-  if (!activeConn.value || !failedConnId.value || !job) return
+  if (!failedConnId.value || !job) return
+  const redisConnId = isRedis.value ? activeConn.value?.id : retryRedisConnId.value
+  if (!redisConnId) {
+    toast.error('Select a Redis connection to push the retried job to')
+    return
+  }
   if (deleteAfter && !canAction('delete')) {
     toast.error('Delete after retry is disabled by feature flags')
     return
@@ -1108,7 +1131,7 @@ async function retrySelectedFailedJob(job: LaravelFailedJob | null, deleteAfter:
   try {
     await retryFailedJob(failedConnId.value, {
       id: job.id,
-      redis_conn_id: activeConn.value.id,
+      redis_conn_id: redisConnId,
       redis_db: selectedDb.value,
       prefix: prefix.value,
       queue: targetQueue,
@@ -1140,7 +1163,12 @@ async function removeFailedJob(job: LaravelFailedJob | null) {
 }
 
 async function bulkRetryFailed(deleteAfter: boolean) {
-  if (!activeConn.value || !failedConnId.value || selectedFailedJobs.value.length === 0) return
+  if (!failedConnId.value || selectedFailedJobs.value.length === 0) return
+  const redisConnId = isRedis.value ? activeConn.value?.id : retryRedisConnId.value
+  if (!redisConnId) {
+    toast.error('Select a Redis connection to push the retried jobs to')
+    return
+  }
   if (deleteAfter && !canAction('delete')) {
     toast.error('Delete after retry is disabled by feature flags')
     return
@@ -1151,7 +1179,7 @@ async function bulkRetryFailed(deleteAfter: boolean) {
     await Promise.all(selectedFailedJobs.value.map(job =>
       retryFailedJob(failedConnId.value!, {
         id: job.id,
-        redis_conn_id: activeConn.value!.id,
+        redis_conn_id: redisConnId!,
         redis_db: selectedDb.value,
         prefix: prefix.value,
         queue: job.queue || selectedQueue.value,
@@ -1268,10 +1296,11 @@ function errorMessage(err: unknown, fallback: string) {
 
 <template>
   <div class="lq-view">
-    <section v-if="!isRedis" class="page-panel lq-empty">
-      <div class="lq-empty__title">No Redis connection selected</div>
+    <section v-if="!isRedis && !isSql" class="page-panel lq-empty">
+      <div class="lq-empty__title">No connection selected</div>
+      <div class="lq-empty__hint">Select a Redis connection to monitor queues, or a SQL database connection to browse failed jobs.</div>
       <div v-if="redisConnections.length" class="lq-picker">
-        <label class="form-label">Redis Connection</label>
+        <label class="form-label">Redis Connection (full queue monitor)</label>
         <select class="base-input" @change="selectRedisConnection(($event.target as HTMLSelectElement).value)">
           <option value="">Select Redis connection</option>
           <option v-for="conn in redisConnections" :key="conn.id" :value="conn.id">
@@ -1279,14 +1308,23 @@ function errorMessage(err: unknown, fallback: string) {
           </option>
         </select>
       </div>
-      <div v-else class="lq-muted">Create a Redis connection first.</div>
+      <div v-if="sqlConnections.length" class="lq-picker" style="margin-top:12px">
+        <label class="form-label">SQL Connection (failed jobs only)</label>
+        <select class="base-input" @change="selectRedisConnection(($event.target as HTMLSelectElement).value)">
+          <option value="">Select SQL connection</option>
+          <option v-for="conn in sqlConnections" :key="conn.id" :value="conn.id">
+            {{ conn.name }} ({{ conn.driver }})
+          </option>
+        </select>
+      </div>
+      <div v-if="!redisConnections.length && !sqlConnections.length" class="lq-muted">Create a connection first.</div>
     </section>
 
-    <template v-else>
+    <template v-else-if="isRedis || isSql">
       <aside class="lq-sidebar">
         <div class="lq-panel-header">
           <span>{{ activeConn?.name }}</span>
-          <span class="lq-driver">RD</span>
+          <span class="lq-driver">{{ ({ postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD' }[activeConn?.driver ?? ''] ?? (activeConn?.driver ?? 'DB').slice(0,2).toUpperCase()) }}</span>
         </div>
 
         <div class="lq-controls">
@@ -1304,20 +1342,41 @@ function errorMessage(err: unknown, fallback: string) {
             <input v-model="profileName" class="base-input" placeholder="Profile name" @keydown.enter="saveProfile" />
             <button class="base-btn base-btn--primary base-btn--sm" @click="saveProfile">Save</button>
           </div>
-          <div class="form-group">
-            <label class="form-label">Redis DB</label>
-            <select v-model.number="selectedDb" class="base-input">
-              <option v-for="db in redisDbIndexes" :key="db" :value="db">DB {{ db }}</option>
-            </select>
-          </div>
-          <div class="form-group">
-            <label class="form-label">Queue Prefix</label>
-            <input v-model="prefix" class="base-input" placeholder="queues" @keydown.enter="loadQueues" />
-          </div>
-          <button class="base-btn base-btn--ghost base-btn--sm" :disabled="loadingQueues" @click="loadQueues">Refresh</button>
+          <template v-if="isRedis">
+            <div class="form-group">
+              <label class="form-label">Redis DB</label>
+              <select v-model.number="selectedDb" class="base-input">
+                <option v-for="db in redisDbIndexes" :key="db" :value="db">DB {{ db }}</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label class="form-label">Queue Prefix</label>
+              <input v-model="prefix" class="base-input" placeholder="queues" @keydown.enter="loadQueues" />
+            </div>
+            <button class="base-btn base-btn--ghost base-btn--sm" :disabled="loadingQueues" @click="loadQueues">Refresh</button>
+          </template>
+          <template v-else>
+            <div class="form-group">
+              <label class="form-label">Redis connection for retry</label>
+              <select v-model.number="retryRedisConnId" class="base-input" title="Pick a Redis connection to push retried jobs back into">
+                <option :value="null">None (disable retry)</option>
+                <option v-for="conn in redisConnections" :key="conn.id" :value="conn.id">{{ conn.name }}</option>
+              </select>
+            </div>
+            <div v-if="retryRedisConnId" class="form-group">
+              <label class="form-label">Redis DB</label>
+              <select v-model.number="selectedDb" class="base-input">
+                <option v-for="db in redisDbIndexes" :key="db" :value="db">DB {{ db }}</option>
+              </select>
+            </div>
+            <div v-if="retryRedisConnId" class="form-group">
+              <label class="form-label">Queue prefix</label>
+              <input v-model="prefix" class="base-input" placeholder="queues" />
+            </div>
+          </template>
         </div>
 
-        <div class="lq-queue-list">
+        <div v-if="isRedis" class="lq-queue-list">
           <button
             v-for="queue in queues"
             :key="queue.name"
@@ -1330,13 +1389,17 @@ function errorMessage(err: unknown, fallback: string) {
           </button>
           <div v-if="!loadingQueues && queues.length === 0" class="lq-muted">No Laravel queues found.</div>
         </div>
+        <div v-else class="lq-queue-list">
+          <div class="lq-muted" style="padding:10px 12px">Showing <strong>failed_jobs</strong> from <em>{{ activeConn?.name }}</em>.<br>Switch to a Redis connection to monitor live queues.</div>
+        </div>
       </aside>
 
       <main class="lq-main">
         <div class="lq-toolbar">
           <div class="lq-toolbar__info">
-            <span class="lq-title">Laravel Queue</span>
-            <span class="lq-meta">{{ prefix }}:{{ selectedQueue }}</span>
+            <span class="lq-title">{{ isSql ? 'Laravel Failed Jobs' : 'Laravel Queue' }}</span>
+            <span v-if="isRedis" class="lq-meta">{{ prefix }}:{{ selectedQueue }}</span>
+            <span v-else class="lq-meta">{{ activeConn?.name }} · failed_jobs</span>
           </div>
           <div class="lq-toolbar__actions">
             <label class="lq-auto">
@@ -1348,19 +1411,25 @@ function errorMessage(err: unknown, fallback: string) {
               <option :value="10">10s</option>
               <option :value="30">30s</option>
             </select>
-            <span v-if="selectedSummary" class="lq-chip">{{ selectedSummary.ready }} ready</span>
-            <span v-if="selectedSummary" class="lq-chip">{{ selectedSummary.delayed }} delayed</span>
-            <span v-if="selectedSummary" class="lq-chip">{{ selectedSummary.reserved }} reserved</span>
-            <span class="lq-chip" :class="{ 'lq-chip--danger': stuckJobs.length }">{{ stuckJobs.length }} stuck</span>
-            <span v-if="queueAlerts.length" class="lq-chip lq-chip--danger">{{ queueAlerts.length }} alerts</span>
+            <template v-if="isRedis">
+              <span v-if="selectedSummary" class="lq-chip">{{ selectedSummary.ready }} ready</span>
+              <span v-if="selectedSummary" class="lq-chip">{{ selectedSummary.delayed }} delayed</span>
+              <span v-if="selectedSummary" class="lq-chip">{{ selectedSummary.reserved }} reserved</span>
+              <span class="lq-chip" :class="{ 'lq-chip--danger': stuckJobs.length }">{{ stuckJobs.length }} stuck</span>
+              <span v-if="queueAlerts.length" class="lq-chip lq-chip--danger">{{ queueAlerts.length }} alerts</span>
+              <span class="lq-chip">oldest {{ oldestJobAge }}</span>
+              <button class="base-btn base-btn--ghost base-btn--sm" :disabled="loadingJobs" @click="loadJobs">Refresh Jobs</button>
+              <button class="base-btn base-btn--danger base-btn--sm" :disabled="!jobs.length || !canAction('clear')" @click="clearSelectedQueue">Clear Queue</button>
+            </template>
+            <template v-else>
+              <span class="lq-chip" :class="{ 'lq-chip--danger': failedJobs.length > 0 }">{{ failedJobs.length }} failed</span>
+              <button class="base-btn base-btn--ghost base-btn--sm" :disabled="loadingFailed" @click="loadFailedJobs">Refresh</button>
+            </template>
             <span v-if="featureFlags.readOnly" class="lq-chip lq-chip--danger">read only</span>
-            <span class="lq-chip">oldest {{ oldestJobAge }}</span>
-            <button class="base-btn base-btn--ghost base-btn--sm" :disabled="loadingJobs" @click="loadJobs">Refresh Jobs</button>
-            <button class="base-btn base-btn--danger base-btn--sm" :disabled="!jobs.length || !canAction('clear')" @click="clearSelectedQueue">Clear Queue</button>
           </div>
         </div>
 
-        <div class="lq-healthbar">
+        <div v-if="isRedis" class="lq-healthbar">
           <span class="lq-health">All queues ready <strong>{{ queueTotals.ready }}</strong></span>
           <span class="lq-health">Delayed <strong>{{ queueTotals.delayed }}</strong></span>
           <span class="lq-health">Reserved <strong>{{ queueTotals.reserved }}</strong></span>
@@ -1517,27 +1586,31 @@ function errorMessage(err: unknown, fallback: string) {
 
         <div class="lq-filterbar">
           <input v-model="search" class="base-input lq-search" placeholder="Search UUID, class, handler, or payload" />
-          <label class="lq-retry-after">
-            <span>Retry after</span>
-            <input v-model.number="retryAfter" class="base-input" type="number" min="1" />
-            <span>seconds</span>
-          </label>
-          <select v-model.number="failedConnId" class="base-input lq-failed-select" title="SQL connection for failed_jobs">
-            <option :value="null">Failed jobs connection</option>
-            <option v-for="conn in sqlConnections" :key="conn.id" :value="conn.id">{{ conn.name }}</option>
-          </select>
-          <button class="base-btn base-btn--ghost base-btn--sm" :disabled="!failedConnId || loadingFailed" @click="loadFailedJobs">Load Failed</button>
+          <template v-if="isRedis">
+            <label class="lq-retry-after">
+              <span>Retry after</span>
+              <input v-model.number="retryAfter" class="base-input" type="number" min="1" />
+              <span>seconds</span>
+            </label>
+            <select v-model.number="failedConnId" class="base-input lq-failed-select" title="SQL connection for failed_jobs">
+              <option :value="null">Failed jobs connection</option>
+              <option v-for="conn in sqlConnections" :key="conn.id" :value="conn.id">{{ conn.name }}</option>
+            </select>
+            <button class="base-btn base-btn--ghost base-btn--sm" :disabled="!failedConnId || loadingFailed" @click="loadFailedJobs">Load Failed</button>
+          </template>
         </div>
 
         <div class="lq-tabs">
-          <button class="lq-tab" :class="{ active: activeState === 'all' }" @click="activeState = 'all'">All <span>{{ jobs.length }}</span></button>
-          <button class="lq-tab" :class="{ active: activeState === 'ready' }" @click="activeState = 'ready'">Ready <span>{{ stateCount('ready') }}</span></button>
-          <button class="lq-tab" :class="{ active: activeState === 'delayed' }" @click="activeState = 'delayed'">Delayed <span>{{ stateCount('delayed') }}</span></button>
-          <button class="lq-tab" :class="{ active: activeState === 'reserved' }" @click="activeState = 'reserved'">Reserved <span>{{ stateCount('reserved') }}</span></button>
+          <template v-if="isRedis">
+            <button class="lq-tab" :class="{ active: activeState === 'all' }" @click="activeState = 'all'">All <span>{{ jobs.length }}</span></button>
+            <button class="lq-tab" :class="{ active: activeState === 'ready' }" @click="activeState = 'ready'">Ready <span>{{ stateCount('ready') }}</span></button>
+            <button class="lq-tab" :class="{ active: activeState === 'delayed' }" @click="activeState = 'delayed'">Delayed <span>{{ stateCount('delayed') }}</span></button>
+            <button class="lq-tab" :class="{ active: activeState === 'reserved' }" @click="activeState = 'reserved'">Reserved <span>{{ stateCount('reserved') }}</span></button>
+          </template>
           <button class="lq-tab" :class="{ active: activeState === 'failed' }" @click="activeState = 'failed'; loadFailedJobs()">Failed <span>{{ failedJobs.length }}</span></button>
         </div>
 
-        <div v-if="activeState !== 'failed' && selectedJobIds.size" class="lq-bulkbar">
+        <div v-if="isRedis && activeState !== 'failed' && selectedJobIds.size" class="lq-bulkbar">
           <span>{{ selectedJobIds.size }} selected</span>
           <button class="base-btn base-btn--ghost base-btn--sm" :disabled="!canAction('retry')" @click="bulkRequeueJobs">Requeue selected</button>
           <button class="base-btn base-btn--danger base-btn--sm" :disabled="!canAction('delete')" @click="bulkDeleteJobs">Delete selected</button>
@@ -1546,8 +1619,8 @@ function errorMessage(err: unknown, fallback: string) {
 
         <div v-if="activeState === 'failed' && selectedFailedJobIds.size" class="lq-bulkbar">
           <span>{{ selectedFailedJobIds.size }} failed selected</span>
-          <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('retry')" @click="bulkRetryFailed(false)">Retry selected</button>
-          <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('retry') || !canAction('delete')" @click="bulkRetryFailed(true)">Retry & delete</button>
+          <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('retry') || (isSql && !retryRedisConnId)" @click="bulkRetryFailed(false)">Retry selected</button>
+          <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('retry') || !canAction('delete') || (isSql && !retryRedisConnId)" @click="bulkRetryFailed(true)">Retry & delete</button>
           <button class="base-btn base-btn--danger base-btn--sm" :disabled="!canAction('delete')" @click="bulkDeleteFailed">Delete failed</button>
           <button class="base-btn base-btn--ghost base-btn--sm" @click="quarantineSelectedFailed">Quarantine</button>
           <button class="base-btn base-btn--ghost base-btn--sm" @click="exportSelectedJobs">Export selected</button>
@@ -1560,7 +1633,7 @@ function errorMessage(err: unknown, fallback: string) {
         </div>
 
         <div class="lq-content">
-          <section v-if="activeState !== 'failed'" class="lq-jobs">
+          <section v-if="isRedis && activeState !== 'failed'" class="lq-jobs">
             <table class="lq-table">
               <thead>
                 <tr>
@@ -1680,8 +1753,18 @@ function errorMessage(err: unknown, fallback: string) {
               </div>
               <div class="lq-detail__actions">
                 <button class="base-btn base-btn--ghost base-btn--sm" @click="copyFailedPayload(selectedFailedJob)">Copy Payload</button>
-                <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('retry')" @click="retrySelectedFailedJob(selectedFailedJob, false)">Retry</button>
-                <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('retry') || !canAction('delete')" @click="retrySelectedFailedJob(selectedFailedJob, true)">Retry & Delete</button>
+                <button
+                  class="base-btn base-btn--primary base-btn--sm"
+                  :disabled="!canAction('retry') || (isSql && !retryRedisConnId)"
+                  :title="isSql && !retryRedisConnId ? 'Select a Redis connection in the sidebar to enable retry' : undefined"
+                  @click="retrySelectedFailedJob(selectedFailedJob, false)"
+                >Retry</button>
+                <button
+                  class="base-btn base-btn--primary base-btn--sm"
+                  :disabled="!canAction('retry') || !canAction('delete') || (isSql && !retryRedisConnId)"
+                  :title="isSql && !retryRedisConnId ? 'Select a Redis connection in the sidebar to enable retry' : undefined"
+                  @click="retrySelectedFailedJob(selectedFailedJob, true)"
+                >Retry & Delete</button>
                 <button class="base-btn base-btn--ghost base-btn--sm" @click="quarantineFailed(selectedFailedJob)">Quarantine</button>
                 <button v-if="quarantinedFailedJobIds.has(selectedFailedJob.id)" class="base-btn base-btn--ghost base-btn--sm" @click="removeFromQuarantine(selectedFailedJob)">Unquarantine</button>
                 <button class="base-btn base-btn--danger base-btn--sm" :disabled="!canAction('delete')" @click="removeFailedJob(selectedFailedJob)">Delete Failed</button>
@@ -1704,8 +1787,8 @@ function errorMessage(err: unknown, fallback: string) {
                 <textarea v-model="editedFailedPayload" class="base-input lq-payload-editor" rows="14" />
                 <div class="lq-editor-actions">
                   <button class="base-btn base-btn--ghost base-btn--sm" @click="editedFailedPayload = formatFailedPayload(selectedFailedJob)">Reset</button>
-                  <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('editedReplay')" @click="retrySelectedFailedJob(selectedFailedJob, false)">Retry Edited</button>
-                  <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('editedReplay') || !canAction('delete')" @click="retrySelectedFailedJob(selectedFailedJob, true)">Retry Edited & Delete</button>
+                  <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('editedReplay') || (isSql && !retryRedisConnId)" @click="retrySelectedFailedJob(selectedFailedJob, false)">Retry Edited</button>
+                  <button class="base-btn base-btn--primary base-btn--sm" :disabled="!canAction('editedReplay') || !canAction('delete') || (isSql && !retryRedisConnId)" @click="retrySelectedFailedJob(selectedFailedJob, true)">Retry Edited & Delete</button>
                 </div>
               </div>
               <pre v-if="detailTab === 'command'" class="lq-payload">{{ failedCommandData(selectedFailedJob) || 'No command data found.' }}</pre>
@@ -1740,6 +1823,13 @@ function errorMessage(err: unknown, fallback: string) {
   color: var(--text-primary);
   font-size: 14px;
   font-weight: 700;
+}
+
+.lq-empty__hint {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin-top: 6px;
+  max-width: 420px;
 }
 
 .lq-picker {


### PR DESCRIPTION
Summary

  This PR introduces a Redis client for the Laravel Queue Monitor, fixes several backend correctness and performance issues, resolves UX friction around multi-driver connections, and polishes the Connections admin UI.

  Backend

  Performance & Correctness (server/db/db.go)
  • Replaced += string concatenation in ConvertQuery with strings.Builder — O(n²) → O(n)
  • Simplified isAlterAdd using strings.HasPrefix
  • Changed SetConnMaxLifetime(0) to 5m (PostgreSQL) / 3m (MySQL) to prevent stale connections
  • Collapsed duplicate logic and added error logging in seedDefaultAdmin

  Graceful Shutdown (server/main.go)
  • startAutoBackup goroutine now accepts context.Context and exits cleanly on shutdown signal

  Data Race & TOCTOU fixes (server/handlers/pool.go)
  • entry.lastUsed was written under a read lock — moved to a write lock after Ping() succeeds
  • Double-close on pool eviction: re-checks current == entry inside the write lock before closing a stale connection

  Notification correctness (server/handlers/notifications.go)
  • insertRowReturningID: only appends RETURNING id for PostgreSQL; MySQL/SQLite now correctly use LastInsertId()
  • processPendingNotificationDeliveries: scans all rows and closes the cursor before dispatching external HTTP calls — prevents holding DB connections open during slow network I/O

  Laravel Queue (server/handlers/laravel_queue.go)
  • deleteLaravelFailedJob: replaced string-formatted id with a parameterized query (DELETE … WHERE id = ?)
  • LaravelQueueFailedJobAction: moved RedisConnID validation before it is used
  • LaravelQueueFailedJobs: added rows.Err() check to catch silent iteration errors

  Laravel Queue Ops (server/handlers/laravel_queue_ops.go)
  • saveLaravelQueueOpsSettings: replaced non-atomic upsert with INSERT … ON DUPLICATE KEY UPDATE for MySQL, eliminating a TOCTOU race condition

  Dashboard (server/handlers/dashboard.go)
  • GetDashboard: detects driver == "redis" early and returns {"driver":"redis"} instead of attempting to open a SQL DSN (was causing 502 Bad Gateway)

  Frontend

  Laravel Queue View (web/src/views/LaravelQueueView.vue)
  • Concurrent API calls on mount/watch using Promise.all
  • Bulk operations (bulkDeleteJobs, bulkRequeueJobs, bulkRetryFailed, bulkDeleteFailed) converted from sequential await loops to Promise.all
  • persistOpsSettings watcher debounced at 600 ms to prevent API spam on rapid input
  • quarantineSelectedFailed switched to Promise.allSettled for accurate partial-failure reporting
  • CSS: added overflow: hidden + min-height: 0 to .lq-view, .lq-main, .lq-sidebar — fixes content not scrolling
  • SQL-direct failed jobs mode: when a SQL (non-Redis) connection is active, the view now opens directly to the Failed tab and queries failed_jobs from that database — no Redis connection required. Retry still works
    by selecting a Redis target in the sidebar. Guards added to retrySelectedFailedJob, bulkRetryFailed, quarantineFailed, and removeFromQuarantine to use the correct connection ID per mode
  • Fixed driver badge showing "POST" (was .toUpperCase().slice(0,4) on "postgres") — now uses proper PG/MY/MS/RD abbreviations

  Dashboard View (web/src/views/DashboardView.vue)
  • Added v-else-if="data.driver === 'redis'" branch to render a Redis-specific card instead of SQL stats — eliminates the 502-triggered blank card

  SQL Studio (web/src/views/DataView.vue)
  • sqlConns computed filters Redis connections out of the + DB picker
  • watch(activeConnId) now skips Redis connections — no attempt to open a SQL session for a Redis conn
  • Added activeConnIsRedis computed and a unified dv-landing page: shows a Redis hint banner when Redis is active, and a grid of clickable SQL connection cards for quick-open. quickOpen(connId) emits set-conn and
    opens the session in one click

  Connections Admin (web/src/views/ConnectionsView.vue)
  • Removed redundant badge--default showing raw conn.driver.toUpperCase() (was clipping "POSTGRES" → "POST")
  • Added driverFullName() helper returning PostgreSQL / MySQL / MariaDB / SQL Server / Redis
  • Redesigned connection row: 40×40 driver badge (left) · name + driver pill + host + folder (center, flex) · Open button + folder select + visibility icon + edit + delete (right). Replaced emoji buttons with proper
    SVG icons.

  ────────────────────────────────────────

  Verification

  ◻ cd server && go test ./...
  ◻ cd web && npm run build
  ◻ Manual UI verification, if applicable

  ────────────────────────────────────────

  Checklist

  ◻ The change is focused and reviewable.
  ◻ Documentation was updated when behavior or configuration changed.
  ◻ No secrets, local databases, logs, or generated build output are committed.
  ◻ Security and permission impact was considered.

  ────────────────────────────────────────

  Screenshots

  ┌─────────────────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────┐
  │                                                                             │                                                                           │
  ├─────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────┤
  │ Redis dashboard card — no more 502                                          │ SQL Studio landing page — quick-open SQL connections when Redis is active │
  │ Laravel Queue — SQL mode — failed jobs load directly from failed_jobs table │ Connections row — clean card with driver label, no "POST" badge           │
  └─────────────────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────┘