### PR TITLE
fix: fix logo database acronym

### DIFF
--- a/web/src/views/LaravelQueueView.vue
+++ b/web/src/views/LaravelQueueView.vue
@@ -1324,7 +1324,7 @@ function errorMessage(err: unknown, fallback: string) {
       <aside class="lq-sidebar">
         <div class="lq-panel-header">
           <span>{{ activeConn?.name }}</span>
-          <span class="lq-driver">{{ ({ postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD' }[activeConn?.driver ?? ''] ?? (activeConn?.driver ?? 'DB').slice(0,2).toUpperCase()) }}</span>
+          <span class="lq-driver">{{ (({ postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD' } as Record<string, string>)[activeConn?.driver ?? ''] ?? (activeConn?.driver ?? 'DB').slice(0,2).toUpperCase()) }}</span>
         </div>
 
         <div class="lq-controls">


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                 
                                                                                                                                                                                                                             
  This PR introduces a Redis pub/sub client for the Laravel Queue Monitor, decouples the failed-jobs view from requiring a Redis connection, fixes several backend correctness and performance issues, and polishes          
  multi-driver UX across the app.                                                                                                                                                                                            
                                                                                                                                                                                                                             
  ### Backend                                                                                                                                                                                                                
                                                                                                                                                                                                                             
  **Performance & Correctness (`server/db/db.go`)**                                                                                                                                                                          
  - Replaced `+=` string concatenation in `ConvertQuery` with `strings.Builder` — O(n²) → O(n)                                                                                                                               
  - Simplified `isAlterAdd` using `strings.HasPrefix`                                                                                                                                                                        
  - Changed `SetConnMaxLifetime(0)` to `5m` (PostgreSQL) / `3m` (MySQL) to prevent stale connections                                                                                                                         
  - Collapsed duplicate logic and added error logging in `seedDefaultAdmin`                                                                                                                                                  
                                                                                                                                                                                                                             
  **Graceful Shutdown (`server/main.go`)**                                                                                                                                                                                   
  - `startAutoBackup` goroutine now accepts `context.Context` and exits cleanly on shutdown signal                                                                                                                           
                                                                                                                                                                                                                             
  **Data Race & TOCTOU fixes (`server/handlers/pool.go`)**                                                                                                                                                                   
  - `entry.lastUsed` was written under a read lock — moved to write lock after `Ping()` succeeds                                                                                                                             
  - Double-close on pool eviction: re-checks `current == entry` inside the write lock before closing a stale connection                                                                                                      
                                                                                                                                                                                                                             
  **Notification correctness (`server/handlers/notifications.go`)**                                                                                                                                                          
  - `insertRowReturningID`: only appends `RETURNING id` for PostgreSQL; MySQL/SQLite now use `LastInsertId()`                                                                                                                
  - `processPendingNotificationDeliveries`: closes DB cursor before dispatching external HTTP calls — prevents holding connections open during slow network I/O                                                              
                                                                                                                                                                                                                             
  **Laravel Queue (`server/handlers/laravel_queue.go`)**                                                                                                                                                                     
  - `deleteLaravelFailedJob`: parameterized query (`DELETE … WHERE id = ?`) replaces string-formatted id                                                                                                                     
  - `LaravelQueueFailedJobAction`: moved `RedisConnID` validation before it is used                                                                                                                                          
  - `LaravelQueueFailedJobs`: added `rows.Err()` check                                                                                                                                                                       
                                                                                                                                                                                                                             
  **Laravel Queue Ops (`server/handlers/laravel_queue_ops.go`)**                                                                                                                                                             
  - `saveLaravelQueueOpsSettings`: atomic `INSERT … ON DUPLICATE KEY UPDATE` for MySQL — eliminates TOCTOU race condition                                                                                                    
                                                                                                                                                                                                                             
  **Dashboard (`server/handlers/dashboard.go`)**                                                                                                                                                                             
  - `GetDashboard`: detects `driver == "redis"` early and returns `{"driver":"redis"}` instead of attempting to open a SQL DSN (was causing 502 Bad Gateway)                                                                 
                                                                                                                                                                                                                             
  ### Frontend                                                                                                                                                                                                               
                                                                                                                                                                                                                             
  **Laravel Queue View (`web/src/views/LaravelQueueView.vue`)**                                                                                                                                                              
  - Concurrent API calls on mount/watch using `Promise.all`                                                                                                                                                                  
  - Bulk operations converted from sequential `await` loops to `Promise.all`                                                                                                                                                 
  - `persistOpsSettings` watcher debounced at 600 ms                                                                                                                                                                         
  - `quarantineSelectedFailed` uses `Promise.allSettled` for accurate partial-failure reporting                                                                                                                              
  - CSS: `overflow: hidden` + `min-height: 0` on `.lq-view`, `.lq-main`, `.lq-sidebar` — fixes content not scrolling                                                                                                         
  - **SQL-direct failed jobs mode**: when a SQL connection is active, the view opens directly to the `Failed` tab and queries `failed_jobs` from that database — no Redis connection required. Retry still works by selecting
   a Redis target in the sidebar. `retrySelectedFailedJob`, `bulkRetryFailed`, `quarantineFailed`, and `removeFromQuarantine` all use the correct connection ID per mode                                                     
  - Fixed driver badge showing `"POST"` (was `.toUpperCase().slice(0,4)` on `"postgres"`)                                                                                                                                    
                                                                                                                                                                                                                             
  **Dashboard View (`web/src/views/DashboardView.vue`)**                                                                                                                                                                     
  - Added `v-else-if="data.driver === 'redis'"` branch to render a Redis-specific card — eliminates the 502-triggered blank card                                                                                             
                                                                                                                                                                                                                             
  **SQL Studio (`web/src/views/DataView.vue`)**                                                                                                                                                                              
  - `sqlConns` computed filters Redis connections out of the `+ DB` picker                                                                                                                                                   
  - `watch(activeConnId)` skips Redis connections — no attempt to open a SQL session for a Redis conn                                                                                                                        
  - Unified `dv-landing` page: Redis hint banner when Redis is active, grid of clickable SQL connection cards with `quickOpen(connId)` for one-click switch + session open                                                   
                                                                                                                                                                                                                             
  **Connections Admin (`web/src/views/ConnectionsView.vue`)**                                                                                                                                                                
  - Removed redundant `badge--default` showing raw `conn.driver.toUpperCase()` (was clipping `"POSTGRES"` → `"POST"`)                                                                                                        
  - Added `driverFullName()` helper: `PostgreSQL` / `MySQL` / `MariaDB` / `SQL Server` / `Redis`                                                                                                                             
  - Redesigned connection row: 40×40 driver badge · name + driver pill + host + folder (flex) · Open + folder select + visibility SVG icon + edit + delete                                                                   
                                                                                                                                                                                                                             
  ## Verification                                                                                                                                                                                                            
                                                                                                                                                                                                                             
  - [x] `cd server && go test ./...`                                                                                                                                                                                         
  - [x] `cd web && npm run build`                                                                                                                                                                                            
  - [x] Manual UI verification, if applicable                                                                                                                                                                                
                                                                                                                                                                                                                             
  ## Checklist                                                                                                                                                                                                               
                                                                                                                                                                                                                             
  - [x] The change is focused and reviewable.                                                                                                                                                                                
  - [x] Documentation was updated when behavior or configuration changed.                                                                                                                                                    
  - [x] No secrets, local databases, logs, or generated build output are committed.                                                                                                                                          
  - [x] Security and permission impact was considered.