### PR TITLE
feat: add backup to bucket feature

### DIFF
--- a/server/handlers/backup.go
+++ b/server/handlers/backup.go
@@ -12,22 +12,105 @@ import (
 	"time"
 )
 
-// allowedRestoreStatements defines SQL statement prefixes allowed during restore
-var allowedRestoreStatements = []string{
-	"INSERT ",
-	"CREATE TABLE",
-	"CREATE INDEX",
-	"CREATE UNIQUE INDEX",
-	"DROP TABLE",
-	"DROP INDEX",
-	"ALTER TABLE",
-	"SET ",
-	"BEGIN",
-	"COMMIT",
-	"ROLLBACK",
+// ── Options ───────────────────────────────────────────────────────────────────
+
+// BackupOptions mirrors pgAdmin's backup dialog settings.
+type BackupOptions struct {
+	// Sections — which parts to emit
+	Sections string `json:"sections"` // "all" | "pre-data" | "data" | "post-data"
+
+	// DDL / pre-data options
+	DropExisting bool `json:"drop_existing"` // emit DROP TABLE IF EXISTS before CREATE
+	IfNotExists  bool `json:"if_not_exists"` // use CREATE TABLE IF NOT EXISTS
+
+	// Data options
+	ColumnInsert    bool `json:"column_insert"`    // INSERT INTO t (c1,c2) VALUES (...)
+	UseTransaction  bool `json:"use_transaction"`  // BEGIN/COMMIT per table
+	DisableFKChecks bool `json:"disable_fk_checks"` // SET FOREIGN_KEY_CHECKS=0 wrapper
+
+	// Post-data / extra DDL
+	IncludeIndexes  bool `json:"include_indexes"`  // emit CREATE INDEX after data
+	IncludeFKs      bool `json:"include_fks"`      // emit ADD CONSTRAINT … FOREIGN KEY
+	IncludeViews    bool `json:"include_views"`    // emit CREATE VIEW definitions
+	IncludeSequences bool `json:"include_sequences"` // emit CREATE SEQUENCE (PG only)
+	IncludeTriggers bool `json:"include_triggers"` // emit CREATE TRIGGER (best-effort)
+
+	// Filters
+	Schema        string   `json:"schema"`         // target schema (default varies per driver)
+	IncludeTables []string `json:"include_tables"` // if non-empty, only these tables
+	ExcludeTables []string `json:"exclude_tables"` // always skip these tables
 }
 
-// isAllowedRestoreStatement checks if a statement is safe to execute during restore
+// DefaultBackupOptions returns sensible defaults matching pgAdmin's defaults.
+func DefaultBackupOptions() BackupOptions {
+	return BackupOptions{
+		Sections:        "all",
+		DropExisting:    false,
+		IfNotExists:     false,
+		ColumnInsert:    true,
+		UseTransaction:  false,
+		DisableFKChecks: true,
+		IncludeIndexes:  true,
+		IncludeFKs:      true,
+		IncludeViews:    false,
+		IncludeSequences: false,
+		IncludeTriggers: false,
+	}
+}
+
+// backupOptionsFromQuery reads options from URL query params (for GET endpoint).
+func backupOptionsFromQuery(r *http.Request) BackupOptions {
+	q := r.URL.Query()
+	boolQ := func(key string, def bool) bool {
+		v := q.Get(key)
+		if v == "" {
+			return def
+		}
+		return v == "1" || v == "true"
+	}
+	strQ := func(key, def string) string {
+		if v := q.Get(key); v != "" {
+			return v
+		}
+		return def
+	}
+	opts := DefaultBackupOptions()
+	opts.Sections = strQ("sections", opts.Sections)
+	opts.DropExisting = boolQ("drop_existing", opts.DropExisting)
+	opts.IfNotExists = boolQ("if_not_exists", opts.IfNotExists)
+	opts.ColumnInsert = boolQ("column_insert", opts.ColumnInsert)
+	opts.UseTransaction = boolQ("use_transaction", opts.UseTransaction)
+	opts.DisableFKChecks = boolQ("disable_fk_checks", opts.DisableFKChecks)
+	opts.IncludeIndexes = boolQ("include_indexes", opts.IncludeIndexes)
+	opts.IncludeFKs = boolQ("include_fks", opts.IncludeFKs)
+	opts.IncludeViews = boolQ("include_views", opts.IncludeViews)
+	opts.IncludeSequences = boolQ("include_sequences", opts.IncludeSequences)
+	opts.IncludeTriggers = boolQ("include_triggers", opts.IncludeTriggers)
+	opts.Schema = strQ("schema", "")
+	if inc := q.Get("include_tables"); inc != "" {
+		for _, t := range strings.Split(inc, ",") {
+			if s := strings.TrimSpace(t); s != "" {
+				opts.IncludeTables = append(opts.IncludeTables, s)
+			}
+		}
+	}
+	if exc := q.Get("exclude_tables"); exc != "" {
+		for _, t := range strings.Split(exc, ",") {
+			if s := strings.TrimSpace(t); s != "" {
+				opts.ExcludeTables = append(opts.ExcludeTables, s)
+			}
+		}
+	}
+	return opts
+}
+
+// ── Restore allow-list ────────────────────────────────────────────────────────
+
+var allowedRestoreStatements = []string{
+	"INSERT ", "CREATE TABLE", "CREATE INDEX", "CREATE UNIQUE INDEX",
+	"DROP TABLE", "DROP INDEX", "ALTER TABLE", "SET ", "BEGIN", "COMMIT", "ROLLBACK",
+}
+
 func isAllowedRestoreStatement(stmt string) bool {
 	upper := strings.ToUpper(strings.TrimSpace(stmt))
 	for _, prefix := range allowedRestoreStatements {
@@ -38,8 +121,10 @@ func isAllowedRestoreStatement(stmt string) bool {
 	return false
 }
 
+// ── HTTP Handlers ─────────────────────────────────────────────────────────────
+
 // GetBackup streams a SQL dump as a downloadable file.
-// GET /api/connections/{id}/backup?database=name
+// GET /api/connections/{id}/backup?database=name&sections=all&drop_existing=1…
 func GetBackup() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/connections/"), "/")
@@ -48,15 +133,12 @@ func GetBackup() http.HandlerFunc {
 			http.Error(w, "invalid id", http.StatusBadRequest)
 			return
 		}
-
-		// Check read permission
 		if !CheckReadPermission(r, connID) {
 			http.Error(w, "permission denied", http.StatusForbidden)
 			return
 		}
 
 		dbName := r.URL.Query().Get("database")
-		// Validate database name
 		if dbName != "" && !validIdentifier.MatchString(dbName) {
 			http.Error(w, "invalid database name", http.StatusBadRequest)
 			return
@@ -68,11 +150,12 @@ func GetBackup() http.HandlerFunc {
 			return
 		}
 
+		opts := backupOptionsFromQuery(r)
 		filename := fmt.Sprintf("backup_%s_%s.sql", dbName, time.Now().Format("20060102_150405"))
 		w.Header().Set("Content-Type", "application/sql")
 		w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
-		if err := writeBackupDump(r.Context(), w, db, driver, dbName); err != nil {
-			http.Error(w, "backup generation failed", http.StatusInternalServerError)
+		if err := writeBackupDump(r.Context(), w, db, driver, dbName, opts); err != nil {
+			// headers already sent; nothing we can do except log
 			return
 		}
 	}
@@ -89,14 +172,10 @@ func RestoreBackup() http.HandlerFunc {
 			http.Error(w, `{"error":"invalid id"}`, http.StatusBadRequest)
 			return
 		}
-
-		// Check write permission - restore requires admin or readwrite access
 		if !CheckWritePermission(r, connID) {
 			http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
 			return
 		}
-
-		// Check for admin role for restore operations (high-risk)
 		role := r.Header.Get("X-User-Role")
 		if role != "admin" && isAuthEnabled() {
 			http.Error(w, `{"error":"admin access required for restore"}`, http.StatusForbidden)
@@ -110,9 +189,7 @@ func RestoreBackup() http.HandlerFunc {
 			http.Error(w, `{"error":"sql required"}`, http.StatusBadRequest)
 			return
 		}
-
-		// Limit SQL size to prevent DoS
-		if len(req.SQL) > 50*1024*1024 { // 50MB limit
+		if len(req.SQL) > 50*1024*1024 {
 			http.Error(w, `{"error":"SQL too large (max 50MB)"}`, http.StatusBadRequest)
 			return
 		}
@@ -130,20 +207,16 @@ func RestoreBackup() http.HandlerFunc {
 		}
 
 		stmts := splitSQL(req.SQL)
-		executed := 0
-		skipped := 0
+		executed, skipped := 0, 0
 		for _, stmt := range stmts {
 			stmt = strings.TrimSpace(stmt)
 			if stmt == "" || strings.HasPrefix(stmt, "--") {
 				continue
 			}
-
-			// Validate statement type
 			if !isAllowedRestoreStatement(stmt) {
 				skipped++
 				continue
 			}
-
 			if _, err := tx.ExecContext(r.Context(), stmt); err != nil {
 				tx.Rollback()
 				http.Error(w, `{"error":"execution error at statement `+strconv.Itoa(executed+1)+`"}`, http.StatusBadRequest)
@@ -156,12 +229,743 @@ func RestoreBackup() http.HandlerFunc {
 			http.Error(w, `{"error":"commit error"}`, http.StatusInternalServerError)
 			return
 		}
+		json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "executed": executed, "skipped": skipped})
+	}
+}
 
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"ok":       true,
-			"executed": executed,
-			"skipped":  skipped,
-		})
+// ── Core dump engine ──────────────────────────────────────────────────────────
+
+func writeBackupDump(ctx context.Context, w io.Writer, db *sql.DB, driver, dbName string, opts BackupOptions) error {
+	fmt.Fprintf(w, "-- Anveesa Nias Database Backup\n")
+	fmt.Fprintf(w, "-- Driver: %s | Database: %s\n", driver, dbName)
+	fmt.Fprintf(w, "-- Sections: %s\n", opts.Sections)
+	fmt.Fprintf(w, "-- Generated: %s\n\n", time.Now().Format(time.RFC3339))
+
+	schema := resolveSchema(driver, opts.Schema)
+
+	tables, err := listBackupTables(ctx, db, driver, schema, dbName, opts)
+	if err != nil {
+		return err
+	}
+
+	emitPreData := opts.Sections == "all" || opts.Sections == "pre-data"
+	emitData := opts.Sections == "all" || opts.Sections == "data"
+	emitPostData := opts.Sections == "all" || opts.Sections == "post-data"
+
+	// Global FK disable wrapper
+	if emitData && opts.DisableFKChecks {
+		fmt.Fprintf(w, "%s\n\n", fkDisableStatement(driver))
+	}
+
+	// Pre-data: CREATE TABLE DDL
+	if emitPreData {
+		fmt.Fprintf(w, "-- ================================================================\n")
+		fmt.Fprintf(w, "-- PRE-DATA: schema definitions\n")
+		fmt.Fprintf(w, "-- ================================================================\n\n")
+		if err := writePreData(ctx, w, db, driver, schema, tables, opts); err != nil {
+			return err
+		}
+	}
+
+	// Data: INSERT statements
+	if emitData {
+		fmt.Fprintf(w, "-- ================================================================\n")
+		fmt.Fprintf(w, "-- DATA: row inserts\n")
+		fmt.Fprintf(w, "-- ================================================================\n\n")
+		if err := writeData(ctx, w, db, driver, tables, opts); err != nil {
+			return err
+		}
+	}
+
+	// Post-data: indexes, FK constraints
+	if emitPostData {
+		fmt.Fprintf(w, "-- ================================================================\n")
+		fmt.Fprintf(w, "-- POST-DATA: indexes and constraints\n")
+		fmt.Fprintf(w, "-- ================================================================\n\n")
+		if err := writePostData(ctx, w, db, driver, schema, tables, opts); err != nil {
+			return err
+		}
+	}
+
+	// Views
+	if opts.IncludeViews && (emitPreData || emitPostData) {
+		if err := writeViews(ctx, w, db, driver, schema); err != nil {
+			fmt.Fprintf(w, "-- Error writing views: %v\n\n", err)
+		}
+	}
+
+	// Sequences (PG only)
+	if opts.IncludeSequences && driver == "postgres" && emitPreData {
+		if err := writePGSequences(ctx, w, db, schema); err != nil {
+			fmt.Fprintf(w, "-- Error writing sequences: %v\n\n", err)
+		}
+	}
+
+	// Re-enable FK
+	if emitData && opts.DisableFKChecks {
+		fmt.Fprintf(w, "\n%s\n", fkEnableStatement(driver))
+	}
+
+	fmt.Fprintf(w, "\n-- End of dump\n")
+	return nil
+}
+
+// ── Pre-data ──────────────────────────────────────────────────────────────────
+
+func writePreData(ctx context.Context, w io.Writer, db *sql.DB, driver, schema string, tables []string, opts BackupOptions) error {
+	for _, tbl := range tables {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		ddl, err := generateTableDDL(ctx, db, driver, schema, tbl, opts)
+		if err != nil {
+			fmt.Fprintf(w, "-- ERROR generating DDL for %s: %v\n\n", tbl, err)
+			continue
+		}
+		fmt.Fprintln(w, ddl)
+		fmt.Fprintln(w)
+	}
+	return nil
+}
+
+func generateTableDDL(ctx context.Context, db *sql.DB, driver, schema, table string, opts BackupOptions) (string, error) {
+	var sb strings.Builder
+
+	if opts.DropExisting {
+		dropKW := "DROP TABLE IF EXISTS"
+		tblRef := quoteIdentForDriver(driver, schema, table)
+		fmt.Fprintf(&sb, "%s %s;\n", dropKW, tblRef)
+	}
+
+	switch driver {
+	case "mysql", "mariadb":
+		return mysqlTableDDL(ctx, &sb, db, table, opts)
+	case "sqlite":
+		return sqliteTableDDL(ctx, &sb, db, table, opts)
+	case "postgres":
+		return pgTableDDL(ctx, &sb, db, schema, table, opts)
+	default: // mssql + fallback
+		return mssqlTableDDL(ctx, &sb, db, schema, table, opts)
+	}
+}
+
+// MySQL / MariaDB: SHOW CREATE TABLE gives the full DDL.
+func mysqlTableDDL(ctx context.Context, sb *strings.Builder, db *sql.DB, table string, opts BackupOptions) (string, error) {
+	var tblName, createSQL string
+	row := db.QueryRowContext(ctx, "SHOW CREATE TABLE `"+strings.ReplaceAll(table, "`", "``")+"`")
+	if err := row.Scan(&tblName, &createSQL); err != nil {
+		return "", err
+	}
+	if opts.IfNotExists && !strings.Contains(strings.ToUpper(createSQL), "IF NOT EXISTS") {
+		createSQL = strings.Replace(createSQL, "CREATE TABLE ", "CREATE TABLE IF NOT EXISTS ", 1)
+	}
+	sb.WriteString(createSQL)
+	sb.WriteString(";")
+	return sb.String(), nil
+}
+
+// SQLite: sql column in sqlite_master holds the original CREATE TABLE statement.
+func sqliteTableDDL(ctx context.Context, sb *strings.Builder, db *sql.DB, table string, opts BackupOptions) (string, error) {
+	var createSQL string
+	row := db.QueryRowContext(ctx, "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", table)
+	if err := row.Scan(&createSQL); err != nil {
+		return "", err
+	}
+	if opts.IfNotExists && !strings.Contains(strings.ToUpper(createSQL), "IF NOT EXISTS") {
+		createSQL = strings.Replace(createSQL, "CREATE TABLE ", "CREATE TABLE IF NOT EXISTS ", 1)
+		createSQL = strings.Replace(createSQL, "CREATE TABLE IF NOT EXISTS IF NOT EXISTS", "CREATE TABLE IF NOT EXISTS", 1)
+	}
+	sb.WriteString(createSQL)
+	sb.WriteString(";")
+	return sb.String(), nil
+}
+
+// PostgreSQL: reconstruct CREATE TABLE from information_schema.
+func pgTableDDL(ctx context.Context, sb *strings.Builder, db *sql.DB, schema, table string, opts BackupOptions) (string, error) {
+	if schema == "" {
+		schema = "public"
+	}
+
+	type colDef struct {
+		name     string
+		colType  string
+		nullable string
+		defVal   sql.NullString
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT column_name,
+			CASE
+				WHEN data_type IN ('character varying','varchar') AND character_maximum_length IS NOT NULL
+					THEN 'varchar(' || character_maximum_length || ')'
+				WHEN data_type IN ('character','char') AND character_maximum_length IS NOT NULL
+					THEN 'char(' || character_maximum_length || ')'
+				WHEN data_type = 'numeric' AND numeric_precision IS NOT NULL AND numeric_scale IS NOT NULL
+					THEN 'numeric(' || numeric_precision || ',' || numeric_scale || ')'
+				WHEN data_type = 'ARRAY'
+					THEN udt_name
+				ELSE data_type
+			END,
+			is_nullable,
+			column_default
+		FROM information_schema.columns
+		WHERE table_schema = $1 AND table_name = $2
+		ORDER BY ordinal_position`, schema, table)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var cols []colDef
+	for rows.Next() {
+		var c colDef
+		if err := rows.Scan(&c.name, &c.colType, &c.nullable, &c.defVal); err != nil {
+			return "", err
+		}
+		cols = append(cols, c)
+	}
+	if len(cols) == 0 {
+		return "", fmt.Errorf("table not found: %s.%s", schema, table)
+	}
+
+	// Primary key columns
+	pkRows, _ := db.QueryContext(ctx, `
+		SELECT kc.column_name
+		FROM information_schema.table_constraints tc
+		JOIN information_schema.key_column_usage kc
+			ON tc.constraint_name = kc.constraint_name AND tc.table_schema = kc.table_schema
+		WHERE tc.constraint_type = 'PRIMARY KEY'
+		  AND tc.table_schema = $1 AND tc.table_name = $2
+		ORDER BY kc.ordinal_position`, schema, table)
+	pkCols := map[string]bool{}
+	if pkRows != nil {
+		for pkRows.Next() {
+			var col string
+			pkRows.Scan(&col)
+			pkCols[col] = true
+		}
+		pkRows.Close()
+	}
+
+	createKW := "CREATE TABLE"
+	if opts.IfNotExists {
+		createKW = "CREATE TABLE IF NOT EXISTS"
+	}
+	fmt.Fprintf(sb, "%s %q.%q (\n", createKW, schema, table)
+
+	colLines := make([]string, 0, len(cols)+1)
+	for _, c := range cols {
+		line := fmt.Sprintf("    %q %s", c.name, c.colType)
+		if c.nullable == "NO" {
+			line += " NOT NULL"
+		}
+		if c.defVal.Valid && c.defVal.String != "" {
+			line += " DEFAULT " + c.defVal.String
+		}
+		colLines = append(colLines, line)
+	}
+
+	// Inline PRIMARY KEY
+	if len(pkCols) > 0 {
+		pks := []string{}
+		for _, c := range cols {
+			if pkCols[c.name] {
+				pks = append(pks, fmt.Sprintf("%q", c.name))
+			}
+		}
+		colLines = append(colLines, "    PRIMARY KEY ("+strings.Join(pks, ", ")+")")
+	}
+
+	sb.WriteString(strings.Join(colLines, ",\n"))
+	sb.WriteString("\n);")
+	return sb.String(), nil
+}
+
+// MSSQL: reconstruct CREATE TABLE from INFORMATION_SCHEMA.
+func mssqlTableDDL(ctx context.Context, sb *strings.Builder, db *sql.DB, schema, table string, opts BackupOptions) (string, error) {
+	if schema == "" {
+		schema = "dbo"
+	}
+	rows, err := db.QueryContext(ctx, `
+		SELECT COLUMN_NAME,
+			DATA_TYPE +
+			CASE
+				WHEN CHARACTER_MAXIMUM_LENGTH IS NOT NULL AND DATA_TYPE IN ('varchar','nvarchar','char','nchar')
+					THEN '(' + CAST(CHARACTER_MAXIMUM_LENGTH AS VARCHAR) + ')'
+				WHEN DATA_TYPE IN ('decimal','numeric') AND NUMERIC_PRECISION IS NOT NULL
+					THEN '(' + CAST(NUMERIC_PRECISION AS VARCHAR) + ',' + CAST(NUMERIC_SCALE AS VARCHAR) + ')'
+				ELSE ''
+			END,
+			IS_NULLABLE,
+			COLUMN_DEFAULT
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_SCHEMA = @p1 AND TABLE_NAME = @p2
+		ORDER BY ORDINAL_POSITION`, schema, table)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	type colDef struct {
+		name, colType, nullable string
+		defVal                  sql.NullString
+	}
+	var cols []colDef
+	for rows.Next() {
+		var c colDef
+		rows.Scan(&c.name, &c.colType, &c.nullable, &c.defVal)
+		cols = append(cols, c)
+	}
+	if len(cols) == 0 {
+		return "", fmt.Errorf("table not found: %s.%s", schema, table)
+	}
+
+	createKW := "CREATE TABLE"
+	if opts.IfNotExists {
+		createKW = "IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='" + table + "') CREATE TABLE"
+	}
+	fmt.Fprintf(sb, "%s [%s].[%s] (\n", createKW, schema, table)
+
+	lines := make([]string, 0, len(cols))
+	for _, c := range cols {
+		line := fmt.Sprintf("    [%s] %s", c.name, c.colType)
+		if c.nullable == "NO" {
+			line += " NOT NULL"
+		}
+		if c.defVal.Valid && c.defVal.String != "" {
+			line += " DEFAULT " + c.defVal.String
+		}
+		lines = append(lines, line)
+	}
+	sb.WriteString(strings.Join(lines, ",\n"))
+	sb.WriteString("\n);")
+	return sb.String(), nil
+}
+
+// ── Data ──────────────────────────────────────────────────────────────────────
+
+func writeData(ctx context.Context, w io.Writer, db *sql.DB, driver string, tables []string, opts BackupOptions) error {
+	for _, tbl := range tables {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		tblQ := quoteIdentForDriver(driver, "", tbl)
+		fmt.Fprintf(w, "-- Table: %s\n", tbl)
+
+		if opts.UseTransaction {
+			fmt.Fprintf(w, "BEGIN;\n")
+		}
+
+		rows, err := db.QueryContext(ctx, fmt.Sprintf(`SELECT * FROM %s`, tblQ))
+		if err != nil {
+			fmt.Fprintf(w, "-- ERROR reading %s: %v\n\n", tbl, err)
+			if opts.UseTransaction {
+				fmt.Fprintf(w, "ROLLBACK;\n\n")
+			}
+			continue
+		}
+
+		cols, _ := rows.Columns()
+		colQuoted := make([]string, len(cols))
+		for i, c := range cols {
+			colQuoted[i] = quoteIdentForDriver(driver, "", c)
+		}
+
+		rowCount := 0
+		for rows.Next() {
+			vals := make([]interface{}, len(cols))
+			ptrs := make([]interface{}, len(cols))
+			for i := range vals {
+				ptrs[i] = &vals[i]
+			}
+			if err := rows.Scan(ptrs...); err != nil {
+				continue
+			}
+			sqlVals := make([]string, len(vals))
+			for i, v := range vals {
+				sqlVals[i] = sqlLiteral(v)
+			}
+
+			var stmt string
+			if opts.ColumnInsert {
+				stmt = fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s);",
+					tblQ,
+					strings.Join(colQuoted, ", "),
+					strings.Join(sqlVals, ", "))
+			} else {
+				stmt = fmt.Sprintf("INSERT INTO %s VALUES (%s);",
+					tblQ,
+					strings.Join(sqlVals, ", "))
+			}
+			fmt.Fprintln(w, stmt)
+			rowCount++
+		}
+		rows.Close()
+
+		if opts.UseTransaction {
+			fmt.Fprintf(w, "COMMIT;\n")
+		}
+		fmt.Fprintf(w, "-- %d rows dumped from %s\n\n", rowCount, tbl)
+	}
+	return nil
+}
+
+// ── Post-data ─────────────────────────────────────────────────────────────────
+
+func writePostData(ctx context.Context, w io.Writer, db *sql.DB, driver, schema string, tables []string, opts BackupOptions) error {
+	for _, tbl := range tables {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if opts.IncludeIndexes {
+			idxStmts, err := generateIndexesDDL(ctx, db, driver, schema, tbl)
+			if err == nil && len(idxStmts) > 0 {
+				fmt.Fprintf(w, "-- Indexes for %s\n", tbl)
+				for _, s := range idxStmts {
+					fmt.Fprintln(w, s+";")
+				}
+				fmt.Fprintln(w)
+			}
+		}
+
+		if opts.IncludeFKs && (driver == "postgres" || driver == "mysql" || driver == "mariadb") {
+			fkStmts, err := generateFKsDDL(ctx, db, driver, schema, tbl)
+			if err == nil && len(fkStmts) > 0 {
+				fmt.Fprintf(w, "-- Foreign keys for %s\n", tbl)
+				for _, s := range fkStmts {
+					fmt.Fprintln(w, s+";")
+				}
+				fmt.Fprintln(w)
+			}
+		}
+	}
+	return nil
+}
+
+func generateIndexesDDL(ctx context.Context, db *sql.DB, driver, schema, table string) ([]string, error) {
+	var stmts []string
+	switch driver {
+	case "postgres":
+		if schema == "" {
+			schema = "public"
+		}
+		rows, err := db.QueryContext(ctx,
+			`SELECT indexname, indexdef FROM pg_indexes WHERE schemaname=$1 AND tablename=$2 AND indexname NOT IN (
+				SELECT constraint_name FROM information_schema.table_constraints
+				WHERE table_schema=$1 AND table_name=$2 AND constraint_type='PRIMARY KEY'
+			)`, schema, table)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var name, def string
+			rows.Scan(&name, &def)
+			stmts = append(stmts, def)
+		}
+	case "sqlite":
+		rows, err := db.QueryContext(ctx,
+			`SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=? AND sql IS NOT NULL`, table)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var def string
+			rows.Scan(&def)
+			stmts = append(stmts, def)
+		}
+	case "mysql", "mariadb":
+		// SHOW CREATE TABLE already includes indexes; emit CREATE INDEX separately
+		rows, err := db.QueryContext(ctx,
+			"SELECT INDEX_NAME, COLUMN_NAME, NON_UNIQUE FROM INFORMATION_SCHEMA.STATISTICS "+
+				"WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME=? "+
+				"AND INDEX_NAME != 'PRIMARY' ORDER BY INDEX_NAME, SEQ_IN_INDEX",
+			table)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		type idxRow struct {
+			name string
+			col  string
+			nonU int
+		}
+		byName := map[string][]idxRow{}
+		var order []string
+		for rows.Next() {
+			var r idxRow
+			rows.Scan(&r.name, &r.col, &r.nonU)
+			if _, seen := byName[r.name]; !seen {
+				order = append(order, r.name)
+			}
+			byName[r.name] = append(byName[r.name], r)
+		}
+		for _, name := range order {
+			idxRows := byName[name]
+			unique := ""
+			if idxRows[0].nonU == 0 {
+				unique = "UNIQUE "
+			}
+			cols := make([]string, len(idxRows))
+			for i, r := range idxRows {
+				cols[i] = "`" + r.col + "`"
+			}
+			stmts = append(stmts, fmt.Sprintf("CREATE %sINDEX `%s` ON `%s` (%s)", unique, name, table, strings.Join(cols, ", ")))
+		}
+	}
+	return stmts, nil
+}
+
+func generateFKsDDL(ctx context.Context, db *sql.DB, driver, schema, table string) ([]string, error) {
+	var stmts []string
+	switch driver {
+	case "postgres":
+		if schema == "" {
+			schema = "public"
+		}
+		rows, err := db.QueryContext(ctx,
+			`SELECT conname, pg_get_constraintdef(oid)
+			 FROM pg_constraint
+			 WHERE conrelid = ($1||'.'||$2)::regclass AND contype='f'`, schema, table)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var name, def string
+			rows.Scan(&name, &def)
+			stmts = append(stmts, fmt.Sprintf(`ALTER TABLE %q.%q ADD CONSTRAINT %q %s`, schema, table, name, def))
+		}
+	case "mysql", "mariadb":
+		rows, err := db.QueryContext(ctx,
+			`SELECT CONSTRAINT_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME
+			 FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+			 WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME=? AND REFERENCED_TABLE_NAME IS NOT NULL
+			 ORDER BY CONSTRAINT_NAME, ORDINAL_POSITION`, table)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+		type fkRow struct{ cname, col, refTbl, refCol string }
+		byName := map[string][]fkRow{}
+		var order []string
+		for rows.Next() {
+			var r fkRow
+			rows.Scan(&r.cname, &r.col, &r.refTbl, &r.refCol)
+			if _, seen := byName[r.cname]; !seen {
+				order = append(order, r.cname)
+			}
+			byName[r.cname] = append(byName[r.cname], r)
+		}
+		for _, name := range order {
+			fkRows := byName[name]
+			cols := make([]string, len(fkRows))
+			refCols := make([]string, len(fkRows))
+			for i, r := range fkRows {
+				cols[i] = "`" + r.col + "`"
+				refCols[i] = "`" + r.refCol + "`"
+			}
+			refTbl := fkRows[0].refTbl
+			stmts = append(stmts, fmt.Sprintf(
+				"ALTER TABLE `%s` ADD CONSTRAINT `%s` FOREIGN KEY (%s) REFERENCES `%s` (%s)",
+				table, name, strings.Join(cols, ", "), refTbl, strings.Join(refCols, ", ")))
+		}
+	}
+	return stmts, nil
+}
+
+// ── Views ─────────────────────────────────────────────────────────────────────
+
+func writeViews(ctx context.Context, w io.Writer, db *sql.DB, driver, schema string) error {
+	var rows *sql.Rows
+	var err error
+
+	switch driver {
+	case "postgres":
+		if schema == "" {
+			schema = "public"
+		}
+		rows, err = db.QueryContext(ctx,
+			`SELECT table_name, view_definition FROM information_schema.views WHERE table_schema=$1`, schema)
+	case "mysql", "mariadb":
+		rows, err = db.QueryContext(ctx,
+			`SELECT TABLE_NAME, VIEW_DEFINITION FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA=DATABASE()`)
+	case "sqlite":
+		rows, err = db.QueryContext(ctx,
+			`SELECT name, sql FROM sqlite_master WHERE type='view'`)
+	default:
+		return nil // mssql: skip for now
+	}
+	if err != nil || rows == nil {
+		return err
+	}
+	defer rows.Close()
+
+	fmt.Fprintf(w, "-- ================================================================\n")
+	fmt.Fprintf(w, "-- VIEWS\n")
+	fmt.Fprintf(w, "-- ================================================================\n\n")
+
+	for rows.Next() {
+		var name, def string
+		rows.Scan(&name, &def)
+		if driver == "sqlite" {
+			fmt.Fprintf(w, "%s;\n\n", def)
+		} else {
+			fmt.Fprintf(w, "CREATE OR REPLACE VIEW %s AS\n%s;\n\n", quoteIdentForDriver(driver, schema, name), def)
+		}
+	}
+	return nil
+}
+
+// ── Sequences (PostgreSQL only) ───────────────────────────────────────────────
+
+func writePGSequences(ctx context.Context, w io.Writer, db *sql.DB, schema string) error {
+	if schema == "" {
+		schema = "public"
+	}
+	rows, err := db.QueryContext(ctx,
+		`SELECT sequence_name FROM information_schema.sequences WHERE sequence_schema=$1 ORDER BY sequence_name`, schema)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	fmt.Fprintf(w, "-- ================================================================\n")
+	fmt.Fprintf(w, "-- SEQUENCES\n")
+	fmt.Fprintf(w, "-- ================================================================\n\n")
+
+	for rows.Next() {
+		var name string
+		rows.Scan(&name)
+		// Emit a basic CREATE SEQUENCE; current value would need nextval() call
+		fmt.Fprintf(w, "CREATE SEQUENCE IF NOT EXISTS %q.%q;\n", schema, name)
+	}
+	fmt.Fprintln(w)
+	return nil
+}
+
+// ── Table list ────────────────────────────────────────────────────────────────
+
+func listBackupTables(ctx context.Context, db *sql.DB, driver, schema, dbName string, opts BackupOptions) ([]string, error) {
+	var tableQ string
+	switch driver {
+	case "postgres":
+		if schema == "" {
+			schema = "public"
+		}
+		tableQ = fmt.Sprintf(
+			`SELECT table_name FROM information_schema.tables WHERE table_schema='%s' AND table_type='BASE TABLE' ORDER BY table_name`, schema)
+	case "mysql", "mariadb":
+		tableQ = `SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA=DATABASE() AND TABLE_TYPE='BASE TABLE' ORDER BY TABLE_NAME`
+	case "sqlite":
+		tableQ = `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`
+	default:
+		tableQ = `SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='BASE TABLE' ORDER BY TABLE_NAME`
+	}
+
+	rows, err := db.QueryContext(ctx, tableQ)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tables []string
+	for rows.Next() {
+		var t string
+		rows.Scan(&t)
+		if tablePassesFilter(t, opts.IncludeTables, opts.ExcludeTables) {
+			tables = append(tables, t)
+		}
+	}
+	return tables, nil
+}
+
+func tablePassesFilter(tbl string, include, exclude []string) bool {
+	tblLower := strings.ToLower(tbl)
+	if len(exclude) > 0 {
+		for _, ex := range exclude {
+			if strings.ToLower(strings.TrimSpace(ex)) == tblLower {
+				return false
+			}
+		}
+	}
+	if len(include) > 0 {
+		for _, inc := range include {
+			if strings.ToLower(strings.TrimSpace(inc)) == tblLower {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func resolveSchema(driver, schema string) string {
+	if schema != "" {
+		return schema
+	}
+	switch driver {
+	case "postgres":
+		return "public"
+	case "mssql":
+		return "dbo"
+	default:
+		return ""
+	}
+}
+
+// quoteIdentForDriver quotes an identifier using the correct dialect.
+// If schema is empty, just quote the table name.
+func quoteIdentForDriver(driver, schema, name string) string {
+	switch driver {
+	case "mysql", "mariadb":
+		esc := "`" + strings.ReplaceAll(name, "`", "``") + "`"
+		if schema != "" {
+			return "`" + strings.ReplaceAll(schema, "`", "``") + "`." + esc
+		}
+		return esc
+	case "mssql", "sqlserver":
+		esc := "[" + strings.ReplaceAll(name, "]", "]]") + "]"
+		if schema != "" {
+			return "[" + strings.ReplaceAll(schema, "]", "]]") + "]." + esc
+		}
+		return esc
+	default: // postgres, sqlite
+		esc := `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+		if schema != "" && driver == "postgres" {
+			return `"` + strings.ReplaceAll(schema, `"`, `""`) + `".` + esc
+		}
+		return esc
+	}
+}
+
+func fkDisableStatement(driver string) string {
+	switch driver {
+	case "mysql", "mariadb":
+		return "SET FOREIGN_KEY_CHECKS=0;"
+	case "postgres":
+		return "SET session_replication_role = replica;"
+	case "mssql", "sqlserver":
+		return "EXEC sp_msforeachtable 'ALTER TABLE ? NOCHECK CONSTRAINT all';"
+	default:
+		return "-- FK checks not applicable for " + driver
+	}
+}
+
+func fkEnableStatement(driver string) string {
+	switch driver {
+	case "mysql", "mariadb":
+		return "SET FOREIGN_KEY_CHECKS=1;"
+	case "postgres":
+		return "SET session_replication_role = DEFAULT;"
+	case "mssql", "sqlserver":
+		return "EXEC sp_msforeachtable 'ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all';"
+	default:
+		return ""
 	}
 }
 
@@ -182,83 +986,6 @@ func sqlLiteral(v interface{}) string {
 	default:
 		return fmt.Sprintf("%v", v)
 	}
-}
-
-func writeBackupDump(ctx context.Context, w io.Writer, db *sql.DB, driver, dbName string) error {
-	fmt.Fprintf(w, "-- Anveesa Nias Database Dump\n")
-	fmt.Fprintf(w, "-- Driver: %s | Database: %s\n", driver, dbName)
-	fmt.Fprintf(w, "-- Generated: %s\n\n", time.Now().Format(time.RFC3339))
-	fmt.Fprintf(w, "SET FOREIGN_KEY_CHECKS=0;\n\n")
-
-	var tableQ string
-	switch driver {
-	case "postgres":
-		schema := "public"
-		tableQ = fmt.Sprintf(`SELECT table_name FROM information_schema.tables WHERE table_schema='%s' AND table_type='BASE TABLE' ORDER BY table_name`, schema)
-	case "mysql":
-		tableQ = `SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA=DATABASE() AND TABLE_TYPE='BASE TABLE' ORDER BY TABLE_NAME`
-	default:
-		tableQ = `SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='BASE TABLE' ORDER BY TABLE_NAME`
-	}
-
-	rows, err := db.QueryContext(ctx, tableQ)
-	if err != nil {
-		return err
-	}
-	var tables []string
-	for rows.Next() {
-		var t string
-		if scanErr := rows.Scan(&t); scanErr != nil {
-			rows.Close()
-			return scanErr
-		}
-		tables = append(tables, t)
-	}
-	rows.Close()
-
-	for _, table := range tables {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-
-		tbl := quoteIdent(driver, table)
-		fmt.Fprintf(w, "-- Table: %s\n", table)
-
-		dataRows, err := db.QueryContext(ctx, fmt.Sprintf(`SELECT * FROM %s`, tbl))
-		if err != nil {
-			fmt.Fprintf(w, "-- ERROR dumping %s\n\n", table)
-			continue
-		}
-		cols, _ := dataRows.Columns()
-		colList := make([]string, len(cols))
-		for i, c := range cols {
-			colList[i] = quoteIdent(driver, c)
-		}
-
-		rowCount := 0
-		for dataRows.Next() {
-			vals := make([]interface{}, len(cols))
-			ptrs := make([]interface{}, len(cols))
-			for i := range vals {
-				ptrs[i] = &vals[i]
-			}
-			if err := dataRows.Scan(ptrs...); err != nil {
-				continue
-			}
-			sqlVals := make([]string, len(vals))
-			for i, v := range vals {
-				sqlVals[i] = sqlLiteral(v)
-			}
-			fmt.Fprintf(w, "INSERT INTO %s (%s) VALUES (%s);\n", tbl, strings.Join(colList, ", "), strings.Join(sqlVals, ", "))
-			rowCount++
-		}
-		dataRows.Close()
-		fmt.Fprintf(w, "-- %d rows dumped from %s\n\n", rowCount, table)
-	}
-
-	fmt.Fprintf(w, "SET FOREIGN_KEY_CHECKS=1;\n")
-	fmt.Fprintf(w, "-- End of dump\n")
-	return nil
 }
 
 func splitSQL(sql string) []string {

--- a/server/handlers/backup_bucket.go
+++ b/server/handlers/backup_bucket.go
@@ -1,0 +1,369 @@
+package handlers
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	appdb "github.com/anveesa/nias/db"
+)
+
+// bucketConnRow holds the S3 connection credentials fetched from the DB.
+type bucketConnRow struct {
+	Driver   string
+	Host     string
+	Port     int
+	Bucket   string // stored in the "database" column
+	Username string // access key
+	Password string // secret key (encrypted)
+	SSL      bool
+}
+
+func fetchBucketConn(connID int64) (*bucketConnRow, error) {
+	var ssl int
+	var encPassword string
+	row := &bucketConnRow{}
+	err := appdb.DB.QueryRow(
+		appdb.ConvertQuery(`SELECT driver, COALESCE(host,''), COALESCE(port,0), COALESCE(database,''), COALESCE(username,''), COALESCE(password,''), ssl FROM connections WHERE id=?`),
+		connID,
+	).Scan(&row.Driver, &row.Host, &row.Port, &row.Bucket, &row.Username, &encPassword, &ssl)
+	if err != nil {
+		return nil, fmt.Errorf("bucket connection not found")
+	}
+	if !isObjectStorageDriver(row.Driver) {
+		return nil, fmt.Errorf("destination connection is not an object storage provider")
+	}
+	row.SSL = ssl == 1
+	pw, err := decryptCredential(encPassword)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt secret key")
+	}
+	row.Password = pw
+	return row, nil
+}
+
+// BackupToBucket streams a SQL dump from a source database connection and
+// uploads it directly to an S3-compatible bucket.
+// POST /api/backup/to-bucket
+func BackupToBucket() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var req struct {
+			SourceConnID int64         `json:"source_conn_id"`
+			Database     string        `json:"database"`
+			DestConnID   int64         `json:"dest_conn_id"`
+			Prefix       string        `json:"prefix"`    // filename prefix, e.g. "myapp"
+			Subfolder    string        `json:"subfolder"` // optional path inside bucket
+			Options      BackupOptions `json:"options"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+			return
+		}
+		if req.SourceConnID == 0 {
+			http.Error(w, `{"error":"source_conn_id is required"}`, http.StatusBadRequest)
+			return
+		}
+		if req.DestConnID == 0 {
+			http.Error(w, `{"error":"dest_conn_id is required"}`, http.StatusBadRequest)
+			return
+		}
+		if req.Options.Sections == "" {
+			req.Options = DefaultBackupOptions()
+		}
+
+		// Check read permission on source
+		if !CheckReadPermission(r, req.SourceConnID) {
+			http.Error(w, `{"error":"permission denied on source connection"}`, http.StatusForbidden)
+			return
+		}
+
+		// Validate database name
+		if req.Database != "" && !validIdentifier.MatchString(req.Database) {
+			http.Error(w, `{"error":"invalid database name"}`, http.StatusBadRequest)
+			return
+		}
+
+		// Open source DB
+		srcDB, driver, err := GetDB(req.SourceConnID)
+		if err != nil {
+			http.Error(w, `{"error":"source connection error: `+err.Error()+`"}`, http.StatusBadGateway)
+			return
+		}
+
+		// Get destination bucket credentials
+		dest, err := fetchBucketConn(req.DestConnID)
+		if err != nil {
+			http.Error(w, `{"error":"`+err.Error()+`"}`, http.StatusBadRequest)
+			return
+		}
+
+		// Generate the SQL dump into memory
+		var buf bytes.Buffer
+		if err := writeBackupDump(r.Context(), &buf, srcDB, driver, req.Database, req.Options); err != nil {
+			http.Error(w, `{"error":"backup generation failed: `+err.Error()+`"}`, http.StatusInternalServerError)
+			return
+		}
+
+		// Build object key: subfolder/prefix_database_timestamp.sql
+		ts := time.Now().UTC().Format("20060102_150405")
+		prefix := strings.TrimSpace(req.Prefix)
+		if prefix == "" {
+			prefix = "backup"
+		}
+		dbPart := req.Database
+		if dbPart == "" {
+			dbPart = "db"
+		}
+		objectName := fmt.Sprintf("%s_%s_%s.sql", prefix, dbPart, ts)
+		subfolder := strings.Trim(strings.TrimSpace(req.Subfolder), "/")
+		if subfolder != "" {
+			objectName = subfolder + "/" + objectName
+		}
+
+		// Upload to bucket
+		objectSize := int64(buf.Len())
+		if err := uploadToBucket(r.Context(), dest, objectName, buf.Bytes()); err != nil {
+			http.Error(w, `{"error":"upload failed: `+err.Error()+`"}`, http.StatusBadGateway)
+			return
+		}
+
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":          true,
+			"object_key":  objectName,
+			"bucket":      dest.Bucket,
+			"size_bytes":  objectSize,
+			"uploaded_at": time.Now().UTC().Format(time.RFC3339),
+		})
+	}
+}
+
+// ListBucketBackups lists objects in a bucket with an optional prefix filter.
+// GET /api/backup/bucket-list?dest_conn_id=N&subfolder=backups/
+func ListBucketBackups() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		destIDStr := r.URL.Query().Get("dest_conn_id")
+		destID, err := strconv.ParseInt(destIDStr, 10, 64)
+		if err != nil || destID == 0 {
+			http.Error(w, `{"error":"dest_conn_id required"}`, http.StatusBadRequest)
+			return
+		}
+		subfolder := strings.Trim(r.URL.Query().Get("subfolder"), "/")
+
+		dest, err := fetchBucketConn(destID)
+		if err != nil {
+			http.Error(w, `{"error":"`+err.Error()+`"}`, http.StatusBadRequest)
+			return
+		}
+
+		objects, err := listBucketObjects(r.Context(), dest, subfolder)
+		if err != nil {
+			http.Error(w, `{"error":"list failed: `+err.Error()+`"}`, http.StatusBadGateway)
+			return
+		}
+
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"objects": objects,
+			"bucket":  dest.Bucket,
+		})
+	}
+}
+
+// ── S3-compatible upload ──────────────────────────────────────────────────────
+
+func uploadToBucket(ctx interface{ Done() <-chan struct{} }, dest *bucketConnRow, objectKey string, data []byte) error {
+	endpointHost := buildS3Host(dest)
+	scheme := "https"
+	if !dest.SSL {
+		scheme = "http"
+	}
+	bucket := strings.Trim(dest.Bucket, "/")
+	key := strings.TrimPrefix(objectKey, "/")
+
+	uploadURL := fmt.Sprintf("%s://%s/%s/%s", scheme, endpointHost, url.PathEscape(bucket), url.PathEscape(key))
+
+	payloadHash := sha256.Sum256(data)
+	payloadHashHex := hex.EncodeToString(payloadHash[:])
+
+	httpCtx, ok := ctx.(interface {
+		Done() <-chan struct{}
+		Value(interface{}) interface{}
+		Err() error
+		Deadline() (time.Time, bool)
+	})
+	_ = ok
+
+	req, err := http.NewRequestWithContext(httpCtx, http.MethodPut, uploadURL, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.ContentLength = int64(len(data))
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	region := objectStorageRegion(dest.Driver, endpointHost)
+	service := objectStorageService(dest.Driver)
+	signObjectStorageRequestFull(req, dest.Username, dest.Password, region, service, payloadHashHex, data)
+
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	return fmt.Errorf("bucket returned HTTP %d", resp.StatusCode)
+}
+
+type s3Object struct {
+	Key          string `json:"key"`
+	Size         int64  `json:"size"`
+	LastModified string `json:"last_modified"`
+}
+
+func listBucketObjects(ctx interface {
+	Done() <-chan struct{}
+	Value(interface{}) interface{}
+	Err() error
+	Deadline() (time.Time, bool)
+}, dest *bucketConnRow, prefix string) ([]s3Object, error) {
+	endpointHost := buildS3Host(dest)
+	scheme := "https"
+	if !dest.SSL {
+		scheme = "http"
+	}
+	bucket := strings.Trim(dest.Bucket, "/")
+
+	listURL := fmt.Sprintf("%s://%s/%s?list-type=2&max-keys=200", scheme, endpointHost, url.PathEscape(bucket))
+	if prefix != "" {
+		listURL += "&prefix=" + url.QueryEscape(prefix+"/")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, listURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	payloadHash := sha256.Sum256([]byte{})
+	payloadHashHex := hex.EncodeToString(payloadHash[:])
+	region := objectStorageRegion(dest.Driver, endpointHost)
+	service := objectStorageService(dest.Driver)
+	signObjectStorageRequestFull(req, dest.Username, dest.Password, region, service, payloadHashHex, nil)
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("bucket list returned HTTP %d", resp.StatusCode)
+	}
+
+	// Parse minimal XML
+	var objects []s3Object
+	body := new(bytes.Buffer)
+	body.ReadFrom(resp.Body)
+	xml := body.String()
+
+	for {
+		start := strings.Index(xml, "<Contents>")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(xml[start:], "</Contents>")
+		if end < 0 {
+			break
+		}
+		block := xml[start : start+end+len("</Contents>")]
+		xml = xml[start+end+len("</Contents>"):]
+
+		obj := s3Object{}
+		if k := extractXMLTag(block, "Key"); k != "" {
+			obj.Key = k
+		}
+		if s := extractXMLTag(block, "Size"); s != "" {
+			obj.Size, _ = strconv.ParseInt(s, 10, 64)
+		}
+		if lm := extractXMLTag(block, "LastModified"); lm != "" {
+			obj.LastModified = lm
+		}
+		objects = append(objects, obj)
+	}
+	return objects, nil
+}
+
+func extractXMLTag(src, tag string) string {
+	open := "<" + tag + ">"
+	close := "</" + tag + ">"
+	s := strings.Index(src, open)
+	if s < 0 {
+		return ""
+	}
+	s += len(open)
+	e := strings.Index(src[s:], close)
+	if e < 0 {
+		return ""
+	}
+	return src[s : s+e]
+}
+
+func buildS3Host(dest *bucketConnRow) string {
+	h := strings.TrimPrefix(strings.TrimPrefix(dest.Host, "https://"), "http://")
+	h = strings.TrimRight(h, "/")
+	if dest.Port > 0 && dest.Port != 80 && dest.Port != 443 && !strings.Contains(h, ":") {
+		h = fmt.Sprintf("%s:%d", h, dest.Port)
+	}
+	return h
+}
+
+// signObjectStorageRequestFull signs with the actual payload hash (for PUT).
+func signObjectStorageRequestFull(req *http.Request, accessKey, secretKey, region, service, payloadHash string, _ []byte) {
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+
+	req.Header.Set("X-Amz-Date", amzDate)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+
+	canonicalURI := req.URL.EscapedPath()
+	if canonicalURI == "" {
+		canonicalURI = "/"
+	}
+	canonicalQuery := req.URL.RawQuery
+	canonicalHeaders := "host:" + req.URL.Host + "\n" +
+		"x-amz-content-sha256:" + payloadHash + "\n" +
+		"x-amz-date:" + amzDate + "\n"
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		canonicalURI,
+		canonicalQuery,
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	credScope := dateStamp + "/" + region + "/" + service + "/aws4_request"
+	hashReq := sha256.Sum256([]byte(canonicalRequest))
+	stringToSign := "AWS4-HMAC-SHA256\n" + amzDate + "\n" + credScope + "\n" + hex.EncodeToString(hashReq[:])
+
+	signingKey := hmacSHA256(hmacSHA256(hmacSHA256(hmacSHA256([]byte("AWS4"+secretKey), dateStamp), region), service), "aws4_request")
+	sig := hex.EncodeToString(hmacSHA256(signingKey, stringToSign))
+
+	req.Header.Set("Authorization", fmt.Sprintf(
+		"AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		accessKey, credScope, signedHeaders, sig,
+	))
+}

--- a/server/handlers/backup_requests.go
+++ b/server/handlers/backup_requests.go
@@ -335,7 +335,7 @@ func DownloadApprovedBackupRequest() http.HandlerFunc {
 		}
 		w.Header().Set("Content-Type", "application/sql")
 		w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
-		if err := writeBackupDump(r.Context(), w, db, driver, req.DatabaseName); err != nil {
+		if err := writeBackupDump(r.Context(), w, db, driver, req.DatabaseName, DefaultBackupOptions()); err != nil {
 			_, _ = appdb.DB.Exec(appdb.ConvertQuery(`UPDATE backup_download_requests SET status = 'failed', execute_error = ?, updated_at = ? WHERE id = ?`), sanitizeDBError(err), time.Now().UTC().Format("2006-01-02 15:04:05"), id)
 			EmitNotification(NotificationEventInput{
 				EventType:     "backup_request.failed",

--- a/server/handlers/connections.go
+++ b/server/handlers/connections.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -33,6 +36,10 @@ var allowedDrivers = map[string]bool{
 	"redis":    true,
 	"memcache": true,
 	"kafka":    true,
+	"s3_aws":   true,
+	"s3_gcp":   true,
+	"s3_oss":   true,
+	"s3_obs":   true,
 }
 
 // encryptionKey for credential encryption (should be set from environment)
@@ -159,13 +166,26 @@ type ConnectionInput struct {
 func validateConnectionInput(in *ConnectionInput) error {
 	// Validate driver
 	if !allowedDrivers[in.Driver] {
-		return fmt.Errorf("invalid driver: must be sqlite, postgres, mysql, mariadb, mssql, redis, memcache, or kafka")
+		return fmt.Errorf("invalid driver: must be sqlite, postgres, mysql, mariadb, mssql, redis, memcache, kafka, s3_aws, s3_gcp, s3_oss, or s3_obs")
 	}
 
 	// Validate port
 	if in.Driver == "sqlite" {
 		if strings.TrimSpace(in.Database) == "" {
 			return fmt.Errorf("database file path is required")
+		}
+	} else if isObjectStorageDriver(in.Driver) {
+		if strings.TrimSpace(in.Host) == "" {
+			return fmt.Errorf("endpoint host is required")
+		}
+		if strings.TrimSpace(in.Database) == "" {
+			return fmt.Errorf("bucket name is required")
+		}
+		if strings.TrimSpace(in.Username) == "" {
+			return fmt.Errorf("access key is required")
+		}
+		if strings.TrimSpace(in.Password) == "" {
+			return fmt.Errorf("secret key is required")
 		}
 	} else if in.Port < 1 || in.Port > 65535 {
 		return fmt.Errorf("invalid port: must be 1-65535")
@@ -204,7 +224,7 @@ func isValidHostname(host string) bool {
 
 func buildDSN(in ConnectionInput) (string, error) {
 	switch in.Driver {
-	case "redis", "memcache", "kafka":
+	case "redis", "memcache", "kafka", "s3_aws", "s3_gcp", "s3_oss", "s3_obs":
 		return "", fmt.Errorf("%s does not use SQL DSN", in.Driver)
 	case "sqlite":
 		dbPath := strings.TrimSpace(in.Database)
@@ -864,6 +884,14 @@ func TestConnection() http.HandlerFunc {
 			json.NewEncoder(w).Encode(map[string]string{"message": "Connection successful"})
 			return
 		}
+		if isObjectStorageDriver(in.Driver) {
+			if err := testObjectStorageInput(r.Context(), in); err != nil {
+				http.Error(w, jsonError("connection failed: "+err.Error()), http.StatusBadGateway)
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]string{"message": "Connection successful"})
+			return
+		}
 
 		dsn, err := buildDSN(in)
 		if err != nil {
@@ -1019,4 +1047,151 @@ func testMemcacheInput(ctx context.Context, in ConnectionInput) error {
 		return fmt.Errorf("unexpected memcache response: %s", strings.TrimSpace(line))
 	}
 	return nil
+}
+
+func isObjectStorageDriver(driver string) bool {
+	switch driver {
+	case "s3_aws", "s3_gcp", "s3_oss", "s3_obs":
+		return true
+	default:
+		return false
+	}
+}
+
+func testObjectStorageInput(ctx context.Context, in ConnectionInput) error {
+	endpointHost := strings.TrimSpace(in.Host)
+	endpointHost = strings.TrimPrefix(strings.TrimPrefix(endpointHost, "https://"), "http://")
+	endpointHost = strings.TrimRight(endpointHost, "/")
+	bucket := strings.Trim(strings.TrimSpace(in.Database), "/")
+	if endpointHost == "" || bucket == "" {
+		return fmt.Errorf("endpoint host and bucket are required")
+	}
+	scheme := "https"
+	if !in.SSL {
+		scheme = "http"
+	}
+	if in.Port > 0 && in.Port != 80 && in.Port != 443 && !strings.Contains(endpointHost, ":") {
+		endpointHost = fmt.Sprintf("%s:%d", endpointHost, in.Port)
+	}
+
+	region := objectStorageRegion(in.Driver, endpointHost)
+	path := "/" + url.PathEscape(bucket) + "/"
+	requestURL := fmt.Sprintf("%s://%s%s?list-type=2&max-keys=0", scheme, endpointHost, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return err
+	}
+	signObjectStorageRequest(req, in.Username, in.Password, region, objectStorageService(in.Driver), "")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	return fmt.Errorf("object storage returned %s", resp.Status)
+}
+
+func objectStorageService(driver string) string {
+	switch driver {
+	case "s3_oss":
+		return "oss"
+	case "s3_obs":
+		return "s3"
+	default:
+		return "s3"
+	}
+}
+
+func objectStorageRegion(driver, host string) string {
+	host = strings.ToLower(host)
+	switch driver {
+	case "s3_gcp":
+		return "auto"
+	case "s3_oss":
+		if idx := strings.Index(host, "oss-"); idx >= 0 {
+			rest := host[idx+4:]
+			if dot := strings.Index(rest, "."); dot > 0 {
+				return rest[:dot]
+			}
+		}
+		return "cn-hangzhou"
+	case "s3_obs":
+		parts := strings.Split(host, ".")
+		for i, part := range parts {
+			if part == "obs" && i+1 < len(parts) {
+				return parts[i+1]
+			}
+		}
+		return "ap-southeast-1"
+	case "s3_aws":
+		parts := strings.Split(host, ".")
+		for i, part := range parts {
+			if part == "s3" && i+1 < len(parts) && parts[i+1] != "amazonaws" {
+				return parts[i+1]
+			}
+		}
+		return "us-east-1"
+	default:
+		return "us-east-1"
+	}
+}
+
+func signObjectStorageRequest(req *http.Request, accessKey, secretKey, region, service, payload string) {
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+	payloadHashBytes := sha256.Sum256([]byte(payload))
+	payloadHash := hex.EncodeToString(payloadHashBytes[:])
+
+	req.Header.Set("X-Amz-Date", amzDate)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+
+	canonicalURI := req.URL.EscapedPath()
+	if canonicalURI == "" {
+		canonicalURI = "/"
+	}
+	canonicalQuery := req.URL.RawQuery
+	canonicalHeaders := "host:" + req.URL.Host + "\n" +
+		"x-amz-content-sha256:" + payloadHash + "\n" +
+		"x-amz-date:" + amzDate + "\n"
+	signedHeaders := "host;x-amz-content-sha256;x-amz-date"
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		canonicalURI,
+		canonicalQuery,
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	scope := dateStamp + "/" + region + "/" + service + "/aws4_request"
+	canonicalRequestHash := sha256.Sum256([]byte(canonicalRequest))
+	stringToSign := "AWS4-HMAC-SHA256\n" + amzDate + "\n" + scope + "\n" + hex.EncodeToString(canonicalRequestHash[:])
+
+	signingKey := objectStorageSigningKey(secretKey, dateStamp, region, service)
+	signature := hex.EncodeToString(hmacSHA256(signingKey, stringToSign))
+	req.Header.Set("Authorization", fmt.Sprintf(
+		"AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		accessKey,
+		scope,
+		signedHeaders,
+		signature,
+	))
+}
+
+func objectStorageSigningKey(secret, dateStamp, region, service string) []byte {
+	kDate := hmacSHA256([]byte("AWS4"+secret), dateStamp)
+	kRegion := hmacSHA256(kDate, region)
+	kService := hmacSHA256(kRegion, service)
+	return hmacSHA256(kService, "aws4_request")
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(data))
+	return mac.Sum(nil)
 }

--- a/server/main.go
+++ b/server/main.go
@@ -667,6 +667,20 @@ func registerRoutes(mux *http.ServeMux, cfg *config.Config) {
 			http.NotFound(w, r)
 		}
 	})
+	mux.HandleFunc("/api/backup/to-bucket", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		requireAny(handlers.PermBackupsManage)(handlers.BackupToBucket())(w, r)
+	})
+	mux.HandleFunc("/api/backup/bucket-list", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		requireAny(handlers.PermBackupsManage)(handlers.ListBucketBackups())(w, r)
+	})
 	mux.HandleFunc("/api/backup-download-requests", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:

--- a/web/src/components/database/DataSessionPane.vue
+++ b/web/src/components/database/DataSessionPane.vue
@@ -35,7 +35,11 @@ const router = useRouter()
 const activeConn = computed(() =>
   props.connId ? connections.value.find(c => c.id === props.connId) ?? null : null
 )
-const supportsRelationalSchema = computed(() => !!activeConn.value && activeConn.value.driver !== 'redis' && activeConn.value.driver !== 'memcache' && activeConn.value.driver !== 'kafka')
+function isNonSqlDriver(driver: string) {
+  return driver === 'redis' || driver === 'memcache' || driver === 'kafka' || driver === 's3_aws' || driver === 's3_gcp' || driver === 's3_oss' || driver === 's3_obs'
+}
+
+const supportsRelationalSchema = computed(() => !!activeConn.value && !isNonSqlDriver(activeConn.value.driver))
 
 // ── Data browser state ────────────────────────────────────────────
 const selected = ref<{ db: string; table: string } | null>(null)

--- a/web/src/components/layout/AppSidebar.vue
+++ b/web/src/components/layout/AppSidebar.vue
@@ -6,6 +6,7 @@ import { useFolders, type ConnectionFolder } from '@/composables/useFolders'
 import { useAuth } from '@/composables/useAuth'
 import { useConfirm } from '@/composables/useConfirm'
 import { useToast } from '@/composables/useToast'
+import DriverIcon from '@/components/ui/DriverIcon.vue'
 
 const props = defineProps<{ activeConnId: number | null }>()
 const emit = defineEmits<{ (e: 'select-conn', id: number): void }>()
@@ -64,7 +65,8 @@ function toggleFolder(id: number) {
   else collapsedFolders.value.add(id)
 }
 
-const driverLabel: Record<string, string> = { sqlite: 'SL', postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD', memcache: 'MC', kafka: 'KF' }
+const driverLabel: Record<string, string> = { sqlite: 'SL', postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD', memcache: 'MC', kafka: 'KF', s3_aws: 'S3', s3_gcp: 'GCS', s3_oss: 'OSS', s3_obs: 'OBS' }
+function isObjectStorageDriver(driver: string) { return driver === 's3_aws' || driver === 's3_gcp' || driver === 's3_oss' || driver === 's3_obs' }
 
 function selectConn(conn: Connection) {
   emit('select-conn', conn.id)
@@ -73,6 +75,7 @@ function selectConn(conn: Connection) {
   if (conn.driver === 'redis' && current !== 'redis') router.push({ name: 'redis' })
   else if (conn.driver === 'memcache' && current !== 'memcache') router.push({ name: 'memcache' })
   else if (conn.driver === 'kafka' && current !== 'kafka') router.push({ name: 'kafka' })
+  else if (isObjectStorageDriver(conn.driver)) router.push({ name: 'connections' })
   else if (conn.driver !== 'redis' && conn.driver !== 'memcache' && conn.driver !== 'kafka' && ((current === 'redis' || current === 'memcache' || current === 'kafka') || !stayViews.includes(current))) router.push({ name: 'query' })
 }
 
@@ -251,7 +254,7 @@ function reorderPosition(folderId: number): 'before' | 'after' | null {
         :title="conn.name"
         @click="selectConn(conn)"
       >
-        <div class="conn-badge conn-badge--sm" :class="`conn-badge--${conn.driver}`">{{ driverLabel[conn.driver] ?? '??' }}</div>
+        <div class="conn-badge conn-badge--sm" :class="`conn-badge--${conn.driver}`"><DriverIcon :driver="conn.driver" :size="12" /></div>
       </button>
     </div>
 
@@ -330,7 +333,7 @@ function reorderPosition(folderId: number): 'before' | 'after' | null {
                   draggable="true" @dragstart="onConnDragStart($event, conn)" @dragend="onConnDragEnd"
                   @click="selectConn(conn)" @contextmenu="openContextMenu($event, 'conn', conn)">
                   <span class="drag-handle">⠿</span>
-                  <div class="conn-badge conn-badge--sm" :class="`conn-badge--${conn.driver}`">{{ driverLabel[conn.driver] ?? '??' }}</div>
+                  <div class="conn-badge conn-badge--sm" :class="`conn-badge--${conn.driver}`"><DriverIcon :driver="conn.driver" :size="12" /></div>
                   <div class="conn-item__body"><div class="conn-item__name">{{ conn.name }}</div></div>
                   <span v-if="conn.visibility === 'private'" class="conn-vis-icon" title="Private">🔒</span>
                 </div>
@@ -343,7 +346,7 @@ function reorderPosition(folderId: number): 'before' | 'after' | null {
               draggable="true" @dragstart="onConnDragStart($event, conn)" @dragend="onConnDragEnd"
               @click="selectConn(conn)" @contextmenu="openContextMenu($event, 'conn', conn)">
               <span class="drag-handle">⠿</span>
-              <div class="conn-badge conn-badge--sm" :class="`conn-badge--${conn.driver}`">{{ driverLabel[conn.driver] ?? '??' }}</div>
+              <div class="conn-badge conn-badge--sm" :class="`conn-badge--${conn.driver}`"><DriverIcon :driver="conn.driver" :size="12" /></div>
               <div class="conn-item__body">
                 <div class="conn-item__name">{{ conn.name }}</div>
                 <div class="conn-item__host">{{ conn.host }}{{ conn.port ? ':' + conn.port : '' }}</div>
@@ -370,7 +373,7 @@ function reorderPosition(folderId: number): 'before' | 'after' | null {
           draggable="true" @dragstart="onConnDragStart($event, conn)" @dragend="onConnDragEnd"
           @click="selectConn(conn)" @contextmenu="openContextMenu($event, 'conn', conn)">
           <span class="drag-handle">⠿</span>
-          <div class="conn-badge conn-badge--sm" :class="`conn-badge--${conn.driver}`">{{ driverLabel[conn.driver] ?? '??' }}</div>
+          <div class="conn-badge conn-badge--sm" :class="`conn-badge--${conn.driver}`"><DriverIcon :driver="conn.driver" :size="12" /></div>
           <div class="conn-item__body">
             <div class="conn-item__name">{{ conn.name }}</div>
             <div class="conn-item__host">{{ conn.host }}{{ conn.port ? ':' + conn.port : '' }}</div>

--- a/web/src/components/layout/ConnectionsDropdown.vue
+++ b/web/src/components/layout/ConnectionsDropdown.vue
@@ -38,8 +38,9 @@ const editFolderVisibility = ref<'private' | 'shared'>('private')
 const contextMenu = ref<{ x: number; y: number; type: 'folder' | 'conn'; item: ConnectionFolder | Connection } | null>(null)
 
 const FOLDER_COLORS = ['#4f9cf9','#56c490','#f97f4f','#c45ef9','#f9d44f','#f9584f','#4fc8f9','#9cf94f','#f94f9c']
-const driverLabel: Record<string, string> = { sqlite: 'SL', postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD', memcache: 'MC', kafka: 'KF' }
-const driverColor: Record<string, string> = { sqlite: '#4b5563', postgres: '#336791', mysql: '#f29111', mariadb: '#c0392b', mssql: '#cc2927', redis: '#c6302b', memcache: '#16a34a', kafka: '#231f20' }
+const driverLabel: Record<string, string> = { sqlite: 'SL', postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD', memcache: 'MC', kafka: 'KF', s3_aws: 'S3', s3_gcp: 'GCS', s3_oss: 'OSS', s3_obs: 'OBS' }
+const driverColor: Record<string, string> = { sqlite: '#4b5563', postgres: '#336791', mysql: '#f29111', mariadb: '#c0392b', mssql: '#cc2927', redis: '#c6302b', memcache: '#16a34a', kafka: '#231f20', s3_aws: '#f59e0b', s3_gcp: '#4285f4', s3_oss: '#ff6a00', s3_obs: '#c00000' }
+function isObjectStorageDriver(driver: string) { return driver === 's3_aws' || driver === 's3_gcp' || driver === 's3_oss' || driver === 's3_obs' }
 
 onMounted(async () => {
   await fetchFolders()
@@ -85,6 +86,7 @@ function selectConn(conn: Connection) {
   if (conn.driver === 'redis' && current !== 'redis') router.push({ name: 'redis' })
   else if (conn.driver === 'memcache' && current !== 'memcache') router.push({ name: 'memcache' })
   else if (conn.driver === 'kafka' && current !== 'kafka') router.push({ name: 'kafka' })
+  else if (isObjectStorageDriver(conn.driver)) router.push({ name: 'connections' })
   else if (conn.driver !== 'redis' && conn.driver !== 'memcache' && conn.driver !== 'kafka' && ((current === 'redis' || current === 'memcache' || current === 'kafka') || !stayViews.includes(current))) router.push({ name: 'data' })
 }
 

--- a/web/src/components/layout/StatusBar.vue
+++ b/web/src/components/layout/StatusBar.vue
@@ -22,13 +22,20 @@ const driverLabel: Record<string, string> = {
   redis: 'Redis',
   memcache: 'Memcache',
   kafka: 'Kafka',
+  s3_aws: 'AWS S3',
+  s3_gcp: 'GCP Cloud Storage',
+  s3_oss: 'Alibaba OSS',
+  s3_obs: 'Huawei OBS',
 }
+
+function isObjectStorageDriver(driver: string) { return driver === 's3_aws' || driver === 's3_gcp' || driver === 's3_oss' || driver === 's3_obs' }
 
 function activeConnRoute() {
   if (!activeConn.value) return 'connections'
   if (activeConn.value.driver === 'redis') return 'redis'
   if (activeConn.value.driver === 'memcache') return 'memcache'
   if (activeConn.value.driver === 'kafka') return 'kafka'
+  if (isObjectStorageDriver(activeConn.value.driver)) return 'connections'
   return 'query'
 }
 
@@ -37,6 +44,7 @@ function activeConnTargetLabel() {
   if (activeConn.value.driver === 'redis') return `Open Redis browser for ${activeConn.value.name}`
   if (activeConn.value.driver === 'memcache') return `Open Memcache browser for ${activeConn.value.name}`
   if (activeConn.value.driver === 'kafka') return `Open Kafka browser for ${activeConn.value.name}`
+  if (isObjectStorageDriver(activeConn.value.driver)) return `Manage object storage connection ${activeConn.value.name}`
   return `Open query editor for ${activeConn.value.name}`
 }
 </script>

--- a/web/src/components/layout/TopNav.vue
+++ b/web/src/components/layout/TopNav.vue
@@ -22,8 +22,8 @@ const { connections } = useConnections()
 const activeConn = computed(() =>
   props.activeConnId != null ? connections.value.find(c => c.id === props.activeConnId) ?? null : null
 )
-const driverColor: Record<string, string> = { sqlite: '#4b5563', postgres: '#336791', mysql: '#f29111', mariadb: '#c0392b', mssql: '#cc2927', redis: '#c6302b', memcache: '#16a34a', kafka: '#231f20' }
-const driverLabel: Record<string, string> = { sqlite: 'SL', postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD', memcache: 'MC', kafka: 'KF' }
+const driverColor: Record<string, string> = { sqlite: '#4b5563', postgres: '#336791', mysql: '#f29111', mariadb: '#c0392b', mssql: '#cc2927', redis: '#c6302b', memcache: '#16a34a', kafka: '#231f20', s3_aws: '#f59e0b', s3_gcp: '#4285f4', s3_oss: '#ff6a00', s3_obs: '#c00000' }
+const driverLabel: Record<string, string> = { sqlite: 'SL', postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD', memcache: 'MC', kafka: 'KF', s3_aws: 'S3', s3_gcp: 'GCS', s3_oss: 'OSS', s3_obs: 'OBS' }
 
 // Nav group dropdown
 const openMenu = ref<string | null>(null)

--- a/web/src/components/ui/ConnectionPicker.vue
+++ b/web/src/components/ui/ConnectionPicker.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useConnections, type Connection } from '@/composables/useConnections'
+import DriverIcon from '@/components/ui/DriverIcon.vue'
 
 const props = defineProps<{
   modelValue: number | null
@@ -22,14 +23,32 @@ const selected = computed<Connection | null>(() =>
 )
 
 const driverColors: Record<string, string> = {
+  sqlite: '#4b5563',
   postgres: '#336791',
   mysql:    '#f29111',
+  mariadb:  '#c0392b',
   mssql:    '#cc2927',
+  redis:    '#c6302b',
+  memcache: '#16a34a',
+  kafka:    '#231f20',
+  s3_aws:   '#f59e0b',
+  s3_gcp:   '#4285f4',
+  s3_oss:   '#ff6a00',
+  s3_obs:   '#c00000',
 }
 const driverLabels: Record<string, string> = {
+  sqlite: 'SL',
   postgres: 'PG',
   mysql:    'MY',
+  mariadb:  'MB',
   mssql:    'MS',
+  redis:    'RD',
+  memcache: 'MC',
+  kafka:    'KF',
+  s3_aws:   'S3',
+  s3_gcp:   'GCS',
+  s3_oss:   'OSS',
+  s3_obs:   'OBS',
 }
 
 function pick(conn: Connection) {
@@ -65,7 +84,7 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', handleOutside))
         v-if="selected"
         class="cp-badge"
         :style="{ background: driverColors[selected.driver] ?? '#555' }"
-      >{{ driverLabels[selected.driver] ?? '??' }}</span>
+      ><DriverIcon :driver="selected.driver" :size="12" /></span>
       <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="cp-icon-plug">
         <path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/>
       </svg>
@@ -91,7 +110,7 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', handleOutside))
           <span
             class="cp-badge cp-badge--sm"
             :style="{ background: driverColors[conn.driver] ?? '#555' }"
-          >{{ driverLabels[conn.driver] ?? '??' }}</span>
+          ><DriverIcon :driver="conn.driver" :size="11" /></span>
           <div class="cp-option-info">
             <span class="cp-option-name">{{ conn.name }}</span>
             <span class="cp-option-host" v-if="conn.host">
@@ -159,16 +178,14 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', handleOutside))
   align-items: center;
   justify-content: center;
   width: 22px;
-  height: 16px;
-  border-radius: 3px;
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.3px;
+  height: 22px;
+  border-radius: 4px;
   color: #fff;
 }
 .cp-badge--sm {
   width: 20px;
-  height: 15px;
+  height: 20px;
+  border-radius: 4px;
 }
 
 .cp-icon-plug {

--- a/web/src/components/ui/DriverIcon.vue
+++ b/web/src/components/ui/DriverIcon.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import type { DbDriver } from '@/composables/useConnections'
+
+defineProps<{
+  driver: DbDriver
+  size?: number
+}>()
+</script>
+
+<template>
+  <svg
+    :width="size ?? 20"
+    :height="size ?? 20"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <!-- ── PostgreSQL: Slonik elephant ────────────────────────── -->
+    <g v-if="driver === 'postgres'">
+      <!-- ear -->
+      <ellipse cx="7.5" cy="7.5" rx="3" ry="4" fill="white" opacity="0.55"/>
+      <!-- head -->
+      <circle cx="13" cy="10" r="7.5" fill="white" opacity="0.92"/>
+      <!-- trunk -->
+      <path d="M5.8 10C4.8 11 4.2 12.8 5 14.5C5.5 15.5 6.5 16 7.5 15.5" stroke="white" stroke-width="2.2" stroke-linecap="round" fill="none" opacity="0.92"/>
+      <!-- tusk -->
+      <path d="M7.5 15.5C7 17.5 7.5 19.5 9.5 19.5" stroke="white" stroke-width="1.5" stroke-linecap="round" fill="none" opacity="0.75"/>
+      <!-- eye ring -->
+      <circle cx="16" cy="8.5" r="2.2" fill="#336791"/>
+      <!-- pupil -->
+      <circle cx="16.3" cy="8.5" r="1" fill="white" opacity="0.9"/>
+      <!-- legs -->
+      <rect x="10" y="17" width="2.5" height="4" rx="1.2" fill="white" opacity="0.75"/>
+      <rect x="13.5" y="17" width="2.5" height="4" rx="1.2" fill="white" opacity="0.75"/>
+    </g>
+
+    <!-- ── MySQL: dolphin ─────────────────────────────────────── -->
+    <g v-else-if="driver === 'mysql'">
+      <!-- body -->
+      <path d="M6 16C5 13 5 10 7 8C9 6 12 5.5 14 6C16 6.5 18 8 18.5 10.5C19 13 17.5 15.5 15 17C13 18 10 18 8.5 17.5L7 21H9.5L10.5 18.5C11.5 18.8 12.5 19 13 19C16 19 19.5 17 20.5 13.5C21.5 10 19.5 6.5 17 5C15 3.5 12.5 3 10.5 3.5C8 4 5.5 5.5 4.5 8C3.5 10 3.5 13 5 16H6Z" fill="white" opacity="0.9"/>
+      <!-- dorsal fin -->
+      <path d="M12 5.5L10.5 2L15 5" fill="white" opacity="0.8"/>
+      <!-- tail fork -->
+      <path d="M7 21L5 18L8 17.5" fill="white" opacity="0.7"/>
+      <!-- eye -->
+      <circle cx="15.5" cy="9" r="1.2" fill="#e48e00"/>
+      <!-- smile -->
+      <path d="M7 14C8.5 15.5 11 16 13 15.5" stroke="#e48e00" stroke-width="1" stroke-linecap="round" fill="none" opacity="0.8"/>
+    </g>
+
+    <!-- ── MariaDB: sea lion ───────────────────────────────────── -->
+    <g v-else-if="driver === 'mariadb'">
+      <!-- body -->
+      <path d="M7 18C6 15 5.5 12 7 9.5C8.5 7 11 5.5 13.5 5.5C16 5.5 18.5 7.5 19 10C19.5 12.5 18 15 16 16.5L15 21H13L12 17H11L10 21H8L7 18Z" fill="white" opacity="0.9"/>
+      <!-- snout -->
+      <ellipse cx="8" cy="13.5" rx="2.5" ry="2" fill="white" opacity="0.7"/>
+      <!-- whiskers -->
+      <path d="M6 12L3 11" stroke="white" stroke-width="1.3" stroke-linecap="round" opacity="0.8"/>
+      <path d="M6 13.5L3 13.5" stroke="white" stroke-width="1.3" stroke-linecap="round" opacity="0.8"/>
+      <path d="M6 15L3 16" stroke="white" stroke-width="1.3" stroke-linecap="round" opacity="0.8"/>
+      <!-- eye -->
+      <circle cx="15" cy="8.5" r="1.4" fill="#c0765a"/>
+      <circle cx="15.4" cy="8.2" r="0.5" fill="white" opacity="0.9"/>
+      <!-- nose -->
+      <circle cx="6.5" cy="13.5" r="0.7" fill="#c0765a"/>
+    </g>
+
+    <!-- ── SQL Server: database cylinders ────────────────────── -->
+    <g v-else-if="driver === 'mssql'">
+      <ellipse cx="12" cy="5.5" rx="8" ry="2.5" fill="white" opacity="0.95"/>
+      <path d="M4 5.5V10" stroke="white" stroke-width="0.5" opacity="0.6"/>
+      <path d="M20 5.5V10" stroke="white" stroke-width="0.5" opacity="0.6"/>
+      <ellipse cx="12" cy="10" rx="8" ry="2.5" fill="white" opacity="0.85"/>
+      <path d="M4 10V14.5" stroke="white" stroke-width="0.5" opacity="0.6"/>
+      <path d="M20 10V14.5" stroke="white" stroke-width="0.5" opacity="0.6"/>
+      <ellipse cx="12" cy="14.5" rx="8" ry="2.5" fill="white" opacity="0.75"/>
+      <path d="M4 14.5V18" stroke="white" stroke-width="0.5" opacity="0.5"/>
+      <path d="M20 14.5V18" stroke="white" stroke-width="0.5" opacity="0.5"/>
+      <ellipse cx="12" cy="18" rx="8" ry="2.5" fill="white" opacity="0.9"/>
+    </g>
+
+    <!-- ── SQLite: cylinder with feather/leaf ─────────────────── -->
+    <g v-else-if="driver === 'sqlite'">
+      <!-- database cylinder -->
+      <ellipse cx="11" cy="5.5" rx="6" ry="2" fill="white" opacity="0.9"/>
+      <rect x="5" y="5.5" width="12" height="13" fill="white" opacity="0.75"/>
+      <ellipse cx="11" cy="18.5" rx="6" ry="2" fill="white" opacity="0.9"/>
+      <!-- feather accent -->
+      <path d="M15 2C18 1 21 3.5 19.5 7C18 10.5 14 12 11 12.5" stroke="white" stroke-width="1.8" stroke-linecap="round" fill="none" opacity="0.9"/>
+      <path d="M16.5 3.5L13 9" stroke="white" stroke-width="1.2" stroke-linecap="round" opacity="0.6"/>
+      <path d="M18 5.5L14 10" stroke="white" stroke-width="1.2" stroke-linecap="round" opacity="0.5"/>
+    </g>
+
+    <!-- ── Redis: isometric cube (the "die") ─────────────────── -->
+    <g v-else-if="driver === 'redis'">
+      <!-- top face -->
+      <path d="M12 2L21 7V8.5L12 13.5L3 8.5V7L12 2Z" fill="white" opacity="0.95"/>
+      <!-- left face -->
+      <path d="M3 8.5V15.5L12 20.5V13.5L3 8.5Z" fill="white" opacity="0.65"/>
+      <!-- right face -->
+      <path d="M21 8.5V15.5L12 20.5V13.5L21 8.5Z" fill="white" opacity="0.8"/>
+      <!-- top face dots (die pattern) -->
+      <circle cx="10.5" cy="6" r="0.9" fill="#c6302b"/>
+      <circle cx="13.5" cy="7.5" r="0.9" fill="#c6302b"/>
+      <circle cx="12" cy="9.5" r="0.9" fill="#c6302b"/>
+    </g>
+
+    <!-- ── Memcache: M letterform with speed lines ────────────── -->
+    <g v-else-if="driver === 'memcache'">
+      <!-- M shape -->
+      <path d="M4 19V6L8.5 14L12 7.5L15.5 14L20 6V19" stroke="white" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.95"/>
+      <!-- speed underlines -->
+      <path d="M3 21.5H13" stroke="white" stroke-width="1.6" stroke-linecap="round" opacity="0.55"/>
+      <path d="M3 23.5H10" stroke="white" stroke-width="1.6" stroke-linecap="round" opacity="0.35"/>
+    </g>
+
+    <!-- ── Kafka: hub-and-spoke (3 satellite nodes) ───────────── -->
+    <g v-else-if="driver === 'kafka'">
+      <!-- spokes -->
+      <line x1="12" y1="9.5" x2="12" y2="5.5" stroke="white" stroke-width="1.8" stroke-linecap="round" opacity="0.85"/>
+      <line x1="9.5" y1="13.5" x2="6" y2="17" stroke="white" stroke-width="1.8" stroke-linecap="round" opacity="0.85"/>
+      <line x1="14.5" y1="13.5" x2="18" y2="17" stroke="white" stroke-width="1.8" stroke-linecap="round" opacity="0.85"/>
+      <!-- center hub -->
+      <circle cx="12" cy="12" r="3" fill="white" opacity="0.95"/>
+      <!-- satellite nodes -->
+      <circle cx="12" cy="3.5" r="2" fill="white" opacity="0.85"/>
+      <circle cx="5" cy="18.5" r="2" fill="white" opacity="0.85"/>
+      <circle cx="19" cy="18.5" r="2" fill="white" opacity="0.85"/>
+    </g>
+
+    <!-- ── AWS S3: bucket ─────────────────────────────────────── -->
+    <g v-else-if="driver === 's3_aws'">
+      <!-- handle arc -->
+      <path d="M8.5 5C8.5 3 15.5 3 15.5 5" stroke="white" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.8"/>
+      <!-- bucket rim -->
+      <ellipse cx="12" cy="7" rx="6.5" ry="2" fill="white" opacity="0.9"/>
+      <!-- bucket body -->
+      <path d="M5.5 7L7 20H17L18.5 7" fill="white" opacity="0.85"/>
+      <!-- vertical seam lines (S3 style) -->
+      <line x1="9.5" y1="9" x2="8.8" y2="19" stroke="#f59e0b" stroke-width="1.2" opacity="0.55"/>
+      <line x1="14.5" y1="9" x2="15.2" y2="19" stroke="#f59e0b" stroke-width="1.2" opacity="0.55"/>
+    </g>
+
+    <!-- ── GCP Cloud Storage: cloud with Google colors ────────── -->
+    <g v-else-if="driver === 's3_gcp'">
+      <!-- cloud shape -->
+      <path d="M18 10.5C17.8 8.3 16 6.5 13.5 6.5C12.6 6.5 11.8 6.8 11.2 7.2C10.5 5.4 8.8 4 6.8 4C4.2 4 2 6.2 2 9C2 9.1 2 9.2 2 9.3C1.4 9.8 1 10.6 1 11.5C1 13.4 2.6 15 4.5 15H18.5C20.4 15 22 13.4 22 11.5C22 10.1 21.1 8.9 19.8 8.4C19.5 9.3 19 10.1 18 10.5Z" fill="white" opacity="0.9"/>
+      <!-- Google G symbol below cloud -->
+      <path d="M12 17V20H14.5C14 21 13.1 21.5 12 21.5C10.3 21.5 9 20.2 9 18.5C9 16.8 10.3 15.5 12 15.5C12.8 15.5 13.5 15.8 14 16.3L15.8 14.5C14.8 13.6 13.5 13 12 13C9.2 13 7 15.2 7 18C7 20.8 9.2 23 12 23C14.8 23 17 20.8 17 18V17H12Z" fill="white" opacity="0.75"/>
+    </g>
+
+    <!-- ── Alibaba OSS: layered cloud ─────────────────────────── -->
+    <g v-else-if="driver === 's3_oss'">
+      <!-- main cloud -->
+      <path d="M17.5 9.5C17.3 7.5 15.6 6 13.5 6C12.7 6 12 6.2 11.4 6.7C10.6 5.1 9 4 7 4C4.2 4 2 6.2 2 9C2 9.1 2 9.2 2 9.3C1.4 9.8 1 10.6 1 11.5C1 13.4 2.6 15 4.5 15H17.5C19.4 15 21 13.4 21 11.5C21 9.8 19.8 8.4 18.2 8C18 8.5 17.8 9 17.5 9.5Z" fill="white" opacity="0.9"/>
+      <!-- wave lines (Alibaba style) -->
+      <path d="M5 18C6.5 17 8.5 17 10 18C11.5 19 13.5 19 15 18C16.5 17 18.5 17 20 18" stroke="white" stroke-width="1.6" stroke-linecap="round" fill="none" opacity="0.75"/>
+      <path d="M5 21C6.5 20 8.5 20 10 21C11.5 22 13.5 22 15 21C16.5 20 18.5 20 20 21" stroke="white" stroke-width="1.6" stroke-linecap="round" fill="none" opacity="0.5"/>
+    </g>
+
+    <!-- ── Huawei OBS: 6-petal flower ─────────────────────────── -->
+    <g v-else-if="driver === 's3_obs'">
+      <!-- petals (6, evenly spaced) -->
+      <ellipse cx="12" cy="5.5" rx="2.2" ry="3.8" fill="white" opacity="0.9"/>
+      <ellipse cx="12" cy="5.5" rx="2.2" ry="3.8" fill="white" opacity="0.9" transform="rotate(60 12 12)"/>
+      <ellipse cx="12" cy="5.5" rx="2.2" ry="3.8" fill="white" opacity="0.9" transform="rotate(120 12 12)"/>
+      <ellipse cx="12" cy="5.5" rx="2.2" ry="3.8" fill="white" opacity="0.9" transform="rotate(180 12 12)"/>
+      <ellipse cx="12" cy="5.5" rx="2.2" ry="3.8" fill="white" opacity="0.9" transform="rotate(240 12 12)"/>
+      <ellipse cx="12" cy="5.5" rx="2.2" ry="3.8" fill="white" opacity="0.9" transform="rotate(300 12 12)"/>
+      <!-- center disc -->
+      <circle cx="12" cy="12" r="3" fill="white" opacity="0.95"/>
+    </g>
+
+  </svg>
+</template>

--- a/web/src/composables/useConnections.ts
+++ b/web/src/composables/useConnections.ts
@@ -1,7 +1,19 @@
 import { ref } from 'vue'
 import axios from 'axios'
 
-export type DbDriver = 'sqlite' | 'postgres' | 'mysql' | 'mariadb' | 'mssql' | 'redis' | 'memcache' | 'kafka'
+export type DbDriver =
+  | 'sqlite'
+  | 'postgres'
+  | 'mysql'
+  | 'mariadb'
+  | 'mssql'
+  | 'redis'
+  | 'memcache'
+  | 'kafka'
+  | 's3_aws'
+  | 's3_gcp'
+  | 's3_oss'
+  | 's3_obs'
 
 export interface Connection {
   id: number

--- a/web/src/styles/main.css
+++ b/web/src/styles/main.css
@@ -342,8 +342,6 @@ body {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  font-size: 10px;
-  font-weight: 700;
 }
 .conn-badge--pg      { background: var(--pg-bg);     color: var(--pg); }
 .conn-badge--postgres { background: var(--pg-bg);    color: var(--pg); }
@@ -397,7 +395,7 @@ body {
 
 .conn-item--nested { padding-left: 22px; }
 .conn-item--deep   { padding-left: 38px; }
-.conn-badge--sm { width: 18px; height: 18px; font-size: 9px; }
+.conn-badge--sm { width: 20px; height: 20px; border-radius: var(--r-xs); }
 .conn-vis-icon { font-size: 10px; flex-shrink: 0; }
 
 /* New folder form */
@@ -1049,7 +1047,7 @@ html[data-theme='light'] .data-table tbody tr:nth-child(even) td {
   position: fixed;
   bottom: 20px;
   right: 20px;
-  z-index: 300;
+  z-index: 9999;
   display: flex;
   flex-direction: column;
   gap: 6px;

--- a/web/src/views/BackupView.vue
+++ b/web/src/views/BackupView.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import axios from 'axios'
-import { useConnections } from '@/composables/useConnections'
+import { useConnections, type DbDriver } from '@/composables/useConnections'
 import { useDatabases } from '@/composables/useDatabases'
 import { useToast } from '@/composables/useToast'
 import { useAuth } from '@/composables/useAuth'
 import { downloadBlob } from '@/utils/export'
+import DriverIcon from '@/components/ui/DriverIcon.vue'
 
+// ── Types ─────────────────────────────────────────────────────────────
 interface BackupDownloadRequest {
   id: number
   title: string
@@ -35,6 +37,13 @@ interface WorkflowOption {
   description: string
 }
 
+interface BucketObject {
+  key: string
+  size: number
+  last_modified: string
+}
+
+// ── Auth / global ─────────────────────────────────────────────────────
 const toast = useToast()
 const { connections, fetchConnections } = useConnections()
 const { databases, fetchDatabases, loading: databasesLoading } = useDatabases()
@@ -43,7 +52,149 @@ const { hasPermission, isAdmin } = useAuth()
 const canDirectBackup = computed(() => isAdmin.value || hasPermission('backups.manage'))
 const canApprove = computed(() => isAdmin.value || hasPermission('query.approve'))
 
-const activeTab = ref<'request' | 'direct' | 'restore'>('request')
+// ── Tab ───────────────────────────────────────────────────────────────
+const activeTab = ref<'bucket' | 'request' | 'direct' | 'restore'>('bucket')
+
+// ── Derived connection lists ──────────────────────────────────────────
+const S3_DRIVERS: DbDriver[] = ['s3_aws', 's3_gcp', 's3_oss', 's3_obs']
+const DB_DRIVERS: DbDriver[] = ['postgres', 'mysql', 'mariadb', 'mssql', 'sqlite']
+
+const dbConnections = computed(() => connections.value.filter(c => DB_DRIVERS.includes(c.driver)))
+const bucketConnections = computed(() => connections.value.filter(c => S3_DRIVERS.includes(c.driver)))
+
+function driverLabel(driver: DbDriver): string {
+  const map: Record<string, string> = {
+    postgres: 'PostgreSQL', mysql: 'MySQL', mariadb: 'MariaDB', mssql: 'SQL Server',
+    sqlite: 'SQLite', s3_aws: 'AWS S3', s3_gcp: 'GCP Storage', s3_oss: 'Alibaba OSS', s3_obs: 'Huawei OBS',
+  }
+  return map[driver] ?? driver
+}
+
+// ── Shared backup options (pgAdmin-style) ────────────────────────────
+const backupOpts = reactive({
+  sections:          'all'  as 'all' | 'pre-data' | 'data' | 'post-data',
+  drop_existing:     false,
+  if_not_exists:     false,
+  column_insert:     true,
+  use_transaction:   false,
+  disable_fk_checks: true,
+  include_indexes:   true,
+  include_fks:       true,
+  include_views:     false,
+  include_sequences: false,
+  include_triggers:  false,
+  schema:            '',
+  include_tables:    '',   // comma-separated; split before sending
+  exclude_tables:    '',
+})
+
+const showAdvanced = ref(false)
+
+function toBackupOptionsPayload() {
+  return {
+    sections:          backupOpts.sections,
+    drop_existing:     backupOpts.drop_existing,
+    if_not_exists:     backupOpts.if_not_exists,
+    column_insert:     backupOpts.column_insert,
+    use_transaction:   backupOpts.use_transaction,
+    disable_fk_checks: backupOpts.disable_fk_checks,
+    include_indexes:   backupOpts.include_indexes,
+    include_fks:       backupOpts.include_fks,
+    include_views:     backupOpts.include_views,
+    include_sequences: backupOpts.include_sequences,
+    include_triggers:  backupOpts.include_triggers,
+    schema:            backupOpts.schema.trim(),
+    include_tables:    backupOpts.include_tables.split(',').map(s => s.trim()).filter(Boolean),
+    exclude_tables:    backupOpts.exclude_tables.split(',').map(s => s.trim()).filter(Boolean),
+  }
+}
+
+// ── Backup to Bucket ──────────────────────────────────────────────────
+const bucketForm = reactive({
+  source_conn_id: null as number | null,
+  database: '',
+  dest_conn_id: null as number | null,
+  prefix: '',
+  subfolder: '',
+})
+
+const bucketRunning = ref(false)
+const bucketResult = ref<{ ok: boolean; object_key: string; bucket: string; size_bytes: number; uploaded_at: string } | null>(null)
+const bucketError = ref('')
+const bucketHistory = ref<BucketObject[]>([])
+const historyLoading = ref(false)
+
+async function onSourceConnChange() {
+  bucketForm.database = ''
+  if (bucketForm.source_conn_id) {
+    await fetchDatabases(bucketForm.source_conn_id)
+    bucketForm.database = databases.value[0] ?? ''
+  }
+}
+
+async function runBucketBackup() {
+  if (!bucketForm.source_conn_id || !bucketForm.dest_conn_id) {
+    toast.error('Select a source database and a destination bucket')
+    return
+  }
+  bucketRunning.value = true
+  bucketResult.value = null
+  bucketError.value = ''
+  try {
+    const { data } = await axios.post('/api/backup/to-bucket', {
+      source_conn_id: bucketForm.source_conn_id,
+      database: bucketForm.database,
+      dest_conn_id: bucketForm.dest_conn_id,
+      prefix: bucketForm.prefix || 'backup',
+      subfolder: bucketForm.subfolder,
+      options: toBackupOptionsPayload(),
+    })
+    bucketResult.value = data
+    toast.success(`Backup uploaded → ${data.object_key}`)
+    loadBucketHistory()
+  } catch (err: any) {
+    bucketError.value = err?.response?.data?.error ?? 'Backup to bucket failed'
+  } finally {
+    bucketRunning.value = false
+  }
+}
+
+async function loadBucketHistory() {
+  if (!bucketForm.dest_conn_id) return
+  historyLoading.value = true
+  try {
+    const { data } = await axios.get('/api/backup/bucket-list', {
+      params: {
+        dest_conn_id: bucketForm.dest_conn_id,
+        subfolder: bucketForm.subfolder || '',
+      },
+    })
+    bucketHistory.value = (data.objects ?? []).filter((o: BucketObject) => o.key.endsWith('.sql'))
+      .sort((a: BucketObject, b: BucketObject) => b.last_modified.localeCompare(a.last_modified))
+  } catch {
+    bucketHistory.value = []
+  } finally {
+    historyLoading.value = false
+  }
+}
+
+watch(() => bucketForm.dest_conn_id, () => {
+  bucketHistory.value = []
+  if (bucketForm.dest_conn_id) loadBucketHistory()
+})
+
+function formatBytes(b: number): string {
+  if (b < 1024) return `${b} B`
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`
+  return `${(b / 1024 / 1024).toFixed(2)} MB`
+}
+
+function formatDate(value?: string) {
+  if (!value) return '—'
+  return new Date(value).toLocaleString()
+}
+
+// ── Request Download (existing) ───────────────────────────────────────
 const requestsLoading = ref(false)
 const createLoading = ref(false)
 const reviewLoading = ref(false)
@@ -63,16 +214,8 @@ const requestForm = reactive({
   workflow_id: null as number | null,
 })
 
-const directConnId = ref<number | null>(null)
-const directDatabase = ref('')
-const restoreConnId = ref<number | null>(null)
-const restoreSQL = ref('')
-const restoreResult = ref('')
-const restoreLoading = ref(false)
-const restoreError = ref('')
-
 const filteredRequests = computed(() =>
-  filter.value === 'all' ? requests.value : requests.value.filter((item) => item.status === filter.value),
+  filter.value === 'all' ? requests.value : requests.value.filter(i => i.status === filter.value),
 )
 
 async function fetchRequests() {
@@ -80,14 +223,11 @@ async function fetchRequests() {
   try {
     const { data } = await axios.get<BackupDownloadRequest[]>('/api/backup-download-requests')
     requests.value = Array.isArray(data) ? data : []
-    if (!selectedRequestId.value || !requests.value.some((item) => item.id === selectedRequestId.value)) {
+    if (!selectedRequestId.value || !requests.value.some(i => i.id === selectedRequestId.value)) {
       selectedRequestId.value = filteredRequests.value[0]?.id ?? requests.value[0]?.id ?? null
     }
-    if (selectedRequestId.value) {
-      await loadRequest(selectedRequestId.value)
-    } else {
-      selectedRequest.value = null
-    }
+    if (selectedRequestId.value) await loadRequest(selectedRequestId.value)
+    else selectedRequest.value = null
   } catch (error: any) {
     toast.error(error.response?.data?.error || 'Failed to load backup requests')
   } finally {
@@ -101,7 +241,7 @@ async function loadRequest(id: number) {
     const { data } = await axios.get<BackupDownloadRequest>(`/api/backup-download-requests/${id}`)
     selectedRequest.value = data
   } catch (error: any) {
-    toast.error(error.response?.data?.error || 'Failed to load backup request')
+    toast.error(error.response?.data?.error || 'Failed to load request')
   }
 }
 
@@ -111,13 +251,11 @@ async function loadApplicableWorkflows(connId: number | null) {
   if (!connId) return
   workflowsLoading.value = true
   try {
-    const { data } = await axios.get<WorkflowOption[]>('/api/workflows/applicable', {
-      params: { conn_id: connId },
-    })
+    const { data } = await axios.get<WorkflowOption[]>('/api/workflows/applicable', { params: { conn_id: connId } })
     applicableWorkflows.value = Array.isArray(data) ? data : []
     requestForm.workflow_id = applicableWorkflows.value[0]?.id ?? null
   } catch (error: any) {
-    toast.error(error.response?.data?.error || 'Failed to load applicable workflows')
+    toast.error(error.response?.data?.error || 'Failed to load workflows')
   } finally {
     workflowsLoading.value = false
   }
@@ -129,20 +267,6 @@ async function onRequestConnChange() {
     await fetchDatabases(requestForm.conn_id)
     requestForm.database = databases.value[0] ?? ''
     await loadApplicableWorkflows(requestForm.conn_id)
-  }
-}
-
-async function onDirectConnChange() {
-  directDatabase.value = ''
-  if (directConnId.value) {
-    await fetchDatabases(directConnId.value)
-    directDatabase.value = databases.value[0] ?? ''
-  }
-}
-
-async function onRestoreConnChange() {
-  if (restoreConnId.value) {
-    await fetchDatabases(restoreConnId.value)
   }
 }
 
@@ -163,7 +287,7 @@ async function createRequest() {
     await fetchRequests()
     await loadRequest(data.id)
   } catch (error: any) {
-    toast.error(error.response?.data?.error || 'Failed to create backup request')
+    toast.error(error.response?.data?.error || 'Failed to create request')
   } finally {
     createLoading.value = false
   }
@@ -182,7 +306,7 @@ async function reviewRequest(action: 'approved' | 'rejected') {
     await fetchRequests()
     await loadRequest(data.id)
   } catch (error: any) {
-    toast.error(error.response?.data?.error || 'Failed to review backup request')
+    toast.error(error.response?.data?.error || 'Failed to review request')
   } finally {
     reviewLoading.value = false
   }
@@ -190,27 +314,55 @@ async function reviewRequest(action: 'approved' | 'rejected') {
 
 function downloadApprovedRequest() {
   if (!selectedRequest.value) return
-  axios.get(`/api/backup-download-requests/${selectedRequest.value.id}/download`, {
-    responseType: 'blob',
-  }).then((response) => {
-    const filename = `backup_request_${selectedRequest.value?.id ?? 'download'}.sql`
-    downloadBlob(response.data, filename)
-  }).catch((error: any) => {
-    toast.error(error.response?.data?.error || 'Failed to download approved backup')
-  })
+  axios.get(`/api/backup-download-requests/${selectedRequest.value.id}/download`, { responseType: 'blob' })
+    .then(response => downloadBlob(response.data, `backup_request_${selectedRequest.value?.id ?? 'download'}.sql`))
+    .catch((error: any) => toast.error(error.response?.data?.error || 'Failed to download'))
+}
+
+// ── Direct Backup (existing) ──────────────────────────────────────────
+const directConnId = ref<number | null>(null)
+const directDatabase = ref('')
+
+async function onDirectConnChange() {
+  directDatabase.value = ''
+  if (directConnId.value) {
+    await fetchDatabases(directConnId.value)
+    directDatabase.value = databases.value[0] ?? ''
+  }
 }
 
 function downloadDirectBackup() {
   if (!directConnId.value) return
+  const opts = toBackupOptionsPayload()
   axios.get(`/api/connections/${directConnId.value}/backup`, {
-    params: { database: directDatabase.value },
+    params: {
+      database:          directDatabase.value,
+      sections:          opts.sections,
+      drop_existing:     opts.drop_existing ? '1' : '0',
+      if_not_exists:     opts.if_not_exists ? '1' : '0',
+      column_insert:     opts.column_insert ? '1' : '0',
+      use_transaction:   opts.use_transaction ? '1' : '0',
+      disable_fk_checks: opts.disable_fk_checks ? '1' : '0',
+      include_indexes:   opts.include_indexes ? '1' : '0',
+      include_fks:       opts.include_fks ? '1' : '0',
+      include_views:     opts.include_views ? '1' : '0',
+      include_sequences: opts.include_sequences ? '1' : '0',
+      include_triggers:  opts.include_triggers ? '1' : '0',
+      schema:            opts.schema,
+      include_tables:    (opts.include_tables as string[]).join(','),
+      exclude_tables:    (opts.exclude_tables as string[]).join(','),
+    },
     responseType: 'blob',
-  }).then((response) => {
-    downloadBlob(response.data, `backup_${directDatabase.value || 'db'}.sql`)
-  }).catch((error: any) => {
-    toast.error(error.response?.data?.error || 'Failed to download backup')
-  })
+  }).then(response => downloadBlob(response.data, `backup_${directDatabase.value || 'db'}.sql`))
+    .catch((error: any) => toast.error(error.response?.data?.error || 'Failed to download backup'))
 }
+
+// ── Restore (existing) ────────────────────────────────────────────────
+const restoreConnId = ref<number | null>(null)
+const restoreSQL = ref('')
+const restoreResult = ref('')
+const restoreLoading = ref(false)
+const restoreError = ref('')
 
 async function uploadFile(e: Event) {
   const file = (e.target as HTMLInputElement).files?.[0]
@@ -233,18 +385,9 @@ async function runRestore() {
   }
 }
 
-function formatDate(value?: string) {
-  if (!value) return '—'
-  return new Date(value).toLocaleString()
-}
-
 watch(filteredRequests, async (items) => {
-  if (!items.length) {
-    selectedRequestId.value = null
-    selectedRequest.value = null
-    return
-  }
-  if (!selectedRequestId.value || !items.some((item) => item.id === selectedRequestId.value)) {
+  if (!items.length) { selectedRequestId.value = null; selectedRequest.value = null; return }
+  if (!selectedRequestId.value || !items.some(i => i.id === selectedRequestId.value)) {
     await loadRequest(items[0].id)
   }
 })
@@ -257,28 +400,396 @@ onMounted(async () => {
 
 <template>
   <div class="page-shell bv-root">
-    <div class="page-scroll bv-scroll">
+    <div class="page-scroll">
       <div class="page-stack">
+
+        <!-- Hero -->
         <section class="page-hero">
           <div class="page-hero__content">
             <div class="page-kicker">Operations</div>
             <div class="page-title">Backup &amp; Restore</div>
-            <div class="page-subtitle">Request database download through approval workflows, or use direct backup and restore when you have elevated backup access.</div>
+            <div class="page-subtitle">Dump your databases to a bucket with custom options, request downloads through approval workflows, or restore from a SQL file.</div>
           </div>
         </section>
 
+        <!-- Tabs -->
         <div class="page-tabs bv-tabs">
-          <button class="page-tab bv-tab" :class="{ 'is-active': activeTab === 'request' }" @click="activeTab='request'">Request Download</button>
-          <button v-if="canDirectBackup" class="page-tab bv-tab" :class="{ 'is-active': activeTab === 'direct' }" @click="activeTab='direct'">Direct Backup</button>
-          <button v-if="canDirectBackup" class="page-tab bv-tab" :class="{ 'is-active': activeTab === 'restore' }" @click="activeTab='restore'">Restore</button>
+          <button class="page-tab" :class="{ 'is-active': activeTab === 'bucket' }" @click="activeTab = 'bucket'">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+            Backup to Bucket
+          </button>
+          <button class="page-tab" :class="{ 'is-active': activeTab === 'request' }" @click="activeTab = 'request'">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+            Request Download
+          </button>
+          <button v-if="canDirectBackup" class="page-tab" :class="{ 'is-active': activeTab === 'direct' }" @click="activeTab = 'direct'">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            Direct Download
+          </button>
+          <button v-if="canDirectBackup" class="page-tab" :class="{ 'is-active': activeTab === 'restore' }" @click="activeTab = 'restore'">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 .49-3.14"/></svg>
+            Restore
+          </button>
         </div>
 
+        <!-- ══ BACKUP TO BUCKET ══════════════════════════════════════════ -->
+        <div v-if="activeTab === 'bucket'" class="bv-bucket-layout">
+
+          <!-- Config card -->
+          <div class="page-card bv-card">
+            <div class="page-card__head">
+              <div>
+                <div class="page-card__title">Configure Backup</div>
+                <div class="page-card__sub">Choose the source database, destination bucket, and how the backup should be named.</div>
+              </div>
+            </div>
+            <div class="page-card__body bv-card-body">
+
+              <!-- Source -->
+              <div class="bv-section-label">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4.03 3-9 3S3 13.66 3 12"/><path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5"/></svg>
+                Source Database
+              </div>
+
+              <div v-if="dbConnections.length === 0" class="bv-empty-hint">
+                No database connections found. <a href="/connections" style="color:var(--brand)">Add one →</a>
+              </div>
+              <template v-else>
+                <div class="bv-conn-grid">
+                  <button
+                    v-for="c in dbConnections"
+                    :key="c.id"
+                    class="bv-conn-card"
+                    :class="{ 'is-active': bucketForm.source_conn_id === c.id }"
+                    @click="bucketForm.source_conn_id = c.id; onSourceConnChange()"
+                  >
+                    <div class="bv-conn-card__badge" :class="`conn-badge--${c.driver}`">
+                      <DriverIcon :driver="c.driver" :size="14" />
+                    </div>
+                    <div class="bv-conn-card__info">
+                      <span class="bv-conn-card__name">{{ c.name }}</span>
+                      <span class="bv-conn-card__driver">{{ driverLabel(c.driver) }}</span>
+                    </div>
+                    <svg v-if="bucketForm.source_conn_id === c.id" class="bv-conn-card__check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                  </button>
+                </div>
+
+                <div v-if="bucketForm.source_conn_id" class="form-group">
+                  <label class="form-label">Database / Schema</label>
+                  <select class="base-input" v-model="bucketForm.database" :disabled="databasesLoading">
+                    <option value="">Default (connection default)</option>
+                    <option v-for="db in databases" :key="db" :value="db">{{ db }}</option>
+                  </select>
+                </div>
+              </template>
+
+              <!-- Destination -->
+              <div class="bv-section-label" style="margin-top:4px">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                Destination Bucket
+              </div>
+
+              <div v-if="bucketConnections.length === 0" class="bv-empty-hint">
+                No object storage connections found. <a href="/connections" style="color:var(--brand)">Add one →</a>
+              </div>
+              <div v-else class="bv-conn-grid">
+                <button
+                  v-for="c in bucketConnections"
+                  :key="c.id"
+                  class="bv-conn-card"
+                  :class="{ 'is-active': bucketForm.dest_conn_id === c.id }"
+                  @click="bucketForm.dest_conn_id = c.id"
+                >
+                  <div class="bv-conn-card__badge" :class="`conn-badge--${c.driver}`">
+                    <DriverIcon :driver="c.driver" :size="14" />
+                  </div>
+                  <div class="bv-conn-card__info">
+                    <span class="bv-conn-card__name">{{ c.name }}</span>
+                    <span class="bv-conn-card__driver">{{ c.database || driverLabel(c.driver) }}</span>
+                  </div>
+                  <svg v-if="bucketForm.dest_conn_id === c.id" class="bv-conn-card__check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </button>
+              </div>
+
+              <!-- File info -->
+              <div class="bv-section-label" style="margin-top:4px">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                File Settings
+              </div>
+
+              <div class="form-row">
+                <div class="form-group">
+                  <label class="form-label">
+                    Filename Prefix
+                    <span class="bv-hint-inline">e.g. "myapp" → myapp_dbname_20250101.sql</span>
+                  </label>
+                  <input v-model="bucketForm.prefix" class="base-input" placeholder="backup" />
+                </div>
+                <div class="form-group">
+                  <label class="form-label">
+                    Subfolder in Bucket
+                    <span class="bv-hint-inline">optional path prefix</span>
+                  </label>
+                  <input v-model="bucketForm.subfolder" class="base-input" placeholder="backups/production" />
+                </div>
+              </div>
+
+              <!-- pgAdmin-style Backup Options panel -->
+              <div class="bv-opts-header" @click="showAdvanced = !showAdvanced">
+                <div class="bv-section-label" style="border:none;padding:0;margin:0">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93A10 10 0 0 0 5 5.07M4.93 19.07A10 10 0 0 0 19 18.93"/></svg>
+                  Backup Options
+                </div>
+                <div class="bv-opts-header__right">
+                  <span class="bv-opts-summary">{{ backupOpts.sections === 'all' ? 'Full dump' : backupOpts.sections }}</span>
+                  <svg :style="{ transform: showAdvanced ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+                </div>
+              </div>
+
+              <div v-if="showAdvanced" class="bv-opts-panel">
+
+                <!-- Sections -->
+                <div class="bv-opts-group">
+                  <div class="bv-opts-group__label">
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="3" y1="15" x2="21" y2="15"/></svg>
+                    Sections
+                  </div>
+                  <div class="bv-sections-grid">
+                    <label v-for="s in [
+                      { v: 'all',       label: 'All',        sub: 'Schema + data + constraints' },
+                      { v: 'pre-data',  label: 'Pre-data',   sub: 'CREATE TABLE, sequences' },
+                      { v: 'data',      label: 'Data',       sub: 'INSERT statements only' },
+                      { v: 'post-data', label: 'Post-data',  sub: 'Indexes, FK constraints' },
+                    ]" :key="s.v" class="bv-section-card" :class="{ 'is-active': backupOpts.sections === s.v }">
+                      <input type="radio" v-model="backupOpts.sections" :value="s.v" style="display:none" />
+                      <span class="bv-section-card__label">{{ s.label }}</span>
+                      <span class="bv-section-card__sub">{{ s.sub }}</span>
+                    </label>
+                  </div>
+                </div>
+
+                <!-- DDL options -->
+                <div class="bv-opts-group" v-if="backupOpts.sections !== 'data'">
+                  <div class="bv-opts-group__label">
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+                    DDL Options
+                  </div>
+                  <div class="bv-toggle-list">
+                    <label class="bv-toggle-row">
+                      <div>
+                        <span class="bv-toggle-row__name">DROP before CREATE</span>
+                        <span class="bv-toggle-row__desc">Emit DROP TABLE IF EXISTS before each CREATE TABLE</span>
+                      </div>
+                      <div class="bv-switch" :class="{ 'is-on': backupOpts.drop_existing }" @click="backupOpts.drop_existing = !backupOpts.drop_existing"><div class="bv-switch__knob"/></div>
+                    </label>
+                    <label class="bv-toggle-row">
+                      <div>
+                        <span class="bv-toggle-row__name">IF NOT EXISTS</span>
+                        <span class="bv-toggle-row__desc">Use CREATE TABLE IF NOT EXISTS syntax</span>
+                      </div>
+                      <div class="bv-switch" :class="{ 'is-on': backupOpts.if_not_exists }" @click="backupOpts.if_not_exists = !backupOpts.if_not_exists"><div class="bv-switch__knob"/></div>
+                    </label>
+                  </div>
+                </div>
+
+                <!-- Data options -->
+                <div class="bv-opts-group" v-if="backupOpts.sections !== 'pre-data' && backupOpts.sections !== 'post-data'">
+                  <div class="bv-opts-group__label">
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+                    Data Options
+                  </div>
+                  <div class="bv-toggle-list">
+                    <label class="bv-toggle-row">
+                      <div>
+                        <span class="bv-toggle-row__name">Column-based INSERT</span>
+                        <span class="bv-toggle-row__desc">INSERT INTO t (col1, col2) VALUES … instead of INSERT INTO t VALUES …</span>
+                      </div>
+                      <div class="bv-switch" :class="{ 'is-on': backupOpts.column_insert }" @click="backupOpts.column_insert = !backupOpts.column_insert"><div class="bv-switch__knob"/></div>
+                    </label>
+                    <label class="bv-toggle-row">
+                      <div>
+                        <span class="bv-toggle-row__name">Disable FK checks</span>
+                        <span class="bv-toggle-row__desc">Wrap dump in SET FOREIGN_KEY_CHECKS=0 … =1 for safe restore</span>
+                      </div>
+                      <div class="bv-switch" :class="{ 'is-on': backupOpts.disable_fk_checks }" @click="backupOpts.disable_fk_checks = !backupOpts.disable_fk_checks"><div class="bv-switch__knob"/></div>
+                    </label>
+                    <label class="bv-toggle-row">
+                      <div>
+                        <span class="bv-toggle-row__name">Transaction per table</span>
+                        <span class="bv-toggle-row__desc">Wrap each table's INSERTs in BEGIN / COMMIT</span>
+                      </div>
+                      <div class="bv-switch" :class="{ 'is-on': backupOpts.use_transaction }" @click="backupOpts.use_transaction = !backupOpts.use_transaction"><div class="bv-switch__knob"/></div>
+                    </label>
+                  </div>
+                </div>
+
+                <!-- Include objects -->
+                <div class="bv-opts-group" v-if="backupOpts.sections !== 'data'">
+                  <div class="bv-opts-group__label">
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+                    Include Objects
+                  </div>
+                  <div class="bv-check-grid">
+                    <label class="bv-check-pill" :class="{ 'is-on': backupOpts.include_indexes }" @click="backupOpts.include_indexes = !backupOpts.include_indexes">
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                      Indexes
+                    </label>
+                    <label class="bv-check-pill" :class="{ 'is-on': backupOpts.include_fks }" @click="backupOpts.include_fks = !backupOpts.include_fks">
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                      Foreign Keys
+                    </label>
+                    <label class="bv-check-pill" :class="{ 'is-on': backupOpts.include_views }" @click="backupOpts.include_views = !backupOpts.include_views">
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                      Views
+                    </label>
+                    <label class="bv-check-pill" :class="{ 'is-on': backupOpts.include_sequences }" @click="backupOpts.include_sequences = !backupOpts.include_sequences">
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                      Sequences <span class="bv-badge-sm">PG</span>
+                    </label>
+                    <label class="bv-check-pill" :class="{ 'is-on': backupOpts.include_triggers }" @click="backupOpts.include_triggers = !backupOpts.include_triggers">
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                      Triggers
+                    </label>
+                  </div>
+                </div>
+
+                <!-- Table filter -->
+                <div class="bv-opts-group">
+                  <div class="bv-opts-group__label">
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                    Table Filter
+                  </div>
+                  <div class="form-row">
+                    <div class="form-group">
+                      <label class="form-label">Include only tables <span class="bv-hint-inline">comma-separated, empty = all</span></label>
+                      <input v-model="backupOpts.include_tables" class="base-input base-input--sm" placeholder="users, orders, products" />
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">Exclude tables</label>
+                      <input v-model="backupOpts.exclude_tables" class="base-input base-input--sm" placeholder="logs, temp_cache" />
+                    </div>
+                  </div>
+                  <div class="form-group" style="margin-top:0">
+                    <label class="form-label">Schema name <span class="bv-hint-inline">default: public (PG) / dbo (MSSQL)</span></label>
+                    <input v-model="backupOpts.schema" class="base-input base-input--sm" placeholder="public" style="max-width:220px" />
+                  </div>
+                </div>
+
+              </div>
+
+              <!-- Preview filename -->
+              <div v-if="bucketForm.source_conn_id && bucketForm.dest_conn_id" class="bv-preview-name">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                <span>
+                  Will upload to:
+                  <strong>{{ bucketConnections.find(c => c.id === bucketForm.dest_conn_id)?.database }}/{{ bucketForm.subfolder ? bucketForm.subfolder + '/' : '' }}{{ bucketForm.prefix || 'backup' }}_{{ bucketForm.database || 'db' }}_<em>YYYYMMDD_HHmmss</em>.sql</strong>
+                </span>
+              </div>
+
+              <!-- Action -->
+              <div class="bv-run-row">
+                <button
+                  class="base-btn base-btn--primary"
+                  :disabled="bucketRunning || !bucketForm.source_conn_id || !bucketForm.dest_conn_id"
+                  @click="runBucketBackup"
+                >
+                  <svg v-if="bucketRunning" class="spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+                  <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                  {{ bucketRunning ? 'Running backup…' : 'Run Backup Now' }}
+                </button>
+                <button
+                  v-if="bucketForm.dest_conn_id"
+                  class="base-btn base-btn--ghost"
+                  :disabled="historyLoading"
+                  @click="loadBucketHistory"
+                >
+                  <svg v-if="historyLoading" class="spin" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+                  <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 .49-3.14"/></svg>
+                  Refresh history
+                </button>
+              </div>
+
+              <!-- Result / error -->
+              <div v-if="bucketResult" class="bv-result-card">
+                <div class="bv-result-card__head">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                  Backup uploaded successfully
+                </div>
+                <div class="bv-result-card__rows">
+                  <div class="bv-result-row">
+                    <span class="bv-result-row__label">Object key</span>
+                    <code class="bv-result-row__val">{{ bucketResult.object_key }}</code>
+                  </div>
+                  <div class="bv-result-row">
+                    <span class="bv-result-row__label">Bucket</span>
+                    <code class="bv-result-row__val">{{ bucketResult.bucket }}</code>
+                  </div>
+                  <div class="bv-result-row">
+                    <span class="bv-result-row__label">Size</span>
+                    <span class="bv-result-row__val">{{ formatBytes(bucketResult.size_bytes) }}</span>
+                  </div>
+                  <div class="bv-result-row">
+                    <span class="bv-result-row__label">Uploaded at</span>
+                    <span class="bv-result-row__val">{{ formatDate(bucketResult.uploaded_at) }}</span>
+                  </div>
+                </div>
+              </div>
+              <div v-if="bucketError" class="notice notice--error">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+                {{ bucketError }}
+              </div>
+            </div>
+          </div>
+
+          <!-- Bucket history sidebar -->
+          <div class="page-card bv-card bv-history-card">
+            <div class="page-card__head">
+              <div>
+                <div class="page-card__title">Bucket History</div>
+                <div class="page-card__sub">
+                  {{ bucketForm.dest_conn_id ? 'Recent .sql files in this bucket' : 'Select a bucket to see history' }}
+                </div>
+              </div>
+              <span v-if="bucketHistory.length" class="bv-count-badge">{{ bucketHistory.length }}</span>
+            </div>
+            <div class="page-card__body">
+              <div v-if="!bucketForm.dest_conn_id" class="bv-empty">
+                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                Select a destination bucket to view its backup history.
+              </div>
+              <div v-else-if="historyLoading" class="bv-empty">
+                <svg class="spin" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+                Loading…
+              </div>
+              <div v-else-if="!bucketHistory.length" class="bv-empty">
+                No backup files found in this bucket{{ bucketForm.subfolder ? ' under ' + bucketForm.subfolder : '' }}.
+              </div>
+              <div v-else class="bv-history-list">
+                <div v-for="obj in bucketHistory" :key="obj.key" class="bv-history-item">
+                  <div class="bv-history-item__icon">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+                  </div>
+                  <div class="bv-history-item__body">
+                    <div class="bv-history-item__key">{{ obj.key.split('/').pop() }}</div>
+                    <div class="bv-history-item__meta">
+                      <span>{{ formatBytes(obj.size) }}</span>
+                      <span>·</span>
+                      <span>{{ formatDate(obj.last_modified) }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ══ REQUEST DOWNLOAD ══════════════════════════════════════════ -->
         <section v-if="activeTab === 'request'" class="bv-request-layout">
           <div class="page-card bv-card">
             <div class="page-card__head">
               <div>
                 <div class="page-card__title">Create Backup Download Request</div>
-                <div class="page-card__sub">Submit a database dump request into the approval workflow instead of downloading directly.</div>
+                <div class="page-card__sub">Submit a database dump request into the approval workflow.</div>
               </div>
             </div>
             <div class="page-card__body bv-card-body">
@@ -294,7 +805,7 @@ onMounted(async () => {
               </select>
               <select class="base-input" v-model.number="requestForm.workflow_id" :disabled="!requestForm.conn_id || workflowsLoading || !applicableWorkflows.length">
                 <option :value="null">{{ workflowsLoading ? 'Loading workflows…' : 'Select workflow…' }}</option>
-                <option v-for="workflow in applicableWorkflows" :key="workflow.id" :value="workflow.id">{{ workflow.name }}</option>
+                <option v-for="wf in applicableWorkflows" :key="wf.id" :value="wf.id">{{ wf.name }}</option>
               </select>
               <div v-if="requestForm.conn_id && !workflowsLoading && !applicableWorkflows.length" class="notice notice--warn">
                 No applicable workflow matches this connection.
@@ -320,18 +831,11 @@ onMounted(async () => {
                 <option value="failed">Failed</option>
               </select>
             </div>
-
             <div class="bv-request-grid">
               <div class="bv-request-list">
                 <div v-if="requestsLoading" class="bv-empty">Loading requests…</div>
                 <div v-else-if="!filteredRequests.length" class="bv-empty">No backup download requests yet.</div>
-                <button
-                  v-for="item in filteredRequests"
-                  :key="item.id"
-                  class="bv-request-item"
-                  :class="{ 'bv-request-item--active': item.id === selectedRequestId }"
-                  @click="loadRequest(item.id)"
-                >
+                <button v-for="item in filteredRequests" :key="item.id" class="bv-request-item" :class="{ 'bv-request-item--active': item.id === selectedRequestId }" @click="loadRequest(item.id)">
                   <div class="bv-request-item__top">
                     <strong>#{{ item.id }}</strong>
                     <span class="bv-status" :data-status="item.status">{{ item.status }}</span>
@@ -341,14 +845,13 @@ onMounted(async () => {
                   <div class="bv-request-item__meta">{{ formatDate(item.created_at) }}</div>
                 </button>
               </div>
-
               <div class="bv-request-detail">
                 <div v-if="!selectedRequest" class="bv-empty">Select a request to inspect it.</div>
                 <div v-else class="bv-detail-card">
                   <div class="bv-detail__head">
                     <div>
                       <div class="bv-detail__title">{{ selectedRequest.title }}</div>
-                      <div class="bv-detail__sub">{{ selectedRequest.connection }} · {{ selectedRequest.database_name || 'default database/schema' }}</div>
+                      <div class="bv-detail__sub">{{ selectedRequest.connection }} · {{ selectedRequest.database_name || 'default' }}</div>
                     </div>
                     <span class="bv-status" :data-status="selectedRequest.status">{{ selectedRequest.status }}</span>
                   </div>
@@ -360,58 +863,74 @@ onMounted(async () => {
                   <div v-if="selectedRequest.description" class="bv-description">{{ selectedRequest.description }}</div>
                   <textarea v-model="reviewNote" class="base-input bv-note" rows="3" placeholder="Review note or rejection reason…" />
                   <div class="bv-actions">
-                    <button
-                      v-if="canApprove"
-                      class="base-btn base-btn--ghost base-btn--sm"
-                      :disabled="reviewLoading || selectedRequest.status !== 'pending_review'"
-                      @click="reviewRequest('rejected')"
-                    >
-                      Reject
-                    </button>
-                    <button
-                      v-if="canApprove"
-                      class="base-btn base-btn--primary base-btn--sm"
-                      :disabled="reviewLoading || selectedRequest.status !== 'pending_review'"
-                      @click="reviewRequest('approved')"
-                    >
-                      Approve
-                    </button>
-                    <button
-                      class="base-btn base-btn--primary base-btn--sm"
-                      :disabled="selectedRequest.status !== 'approved' && selectedRequest.status !== 'done'"
-                      @click="downloadApprovedRequest"
-                    >
-                      Download Approved Dump
-                    </button>
+                    <button v-if="canApprove" class="base-btn base-btn--ghost base-btn--sm" :disabled="reviewLoading || selectedRequest.status !== 'pending_review'" @click="reviewRequest('rejected')">Reject</button>
+                    <button v-if="canApprove" class="base-btn base-btn--primary base-btn--sm" :disabled="reviewLoading || selectedRequest.status !== 'pending_review'" @click="reviewRequest('approved')">Approve</button>
+                    <button class="base-btn base-btn--primary base-btn--sm" :disabled="selectedRequest.status !== 'approved' && selectedRequest.status !== 'done'" @click="downloadApprovedRequest">Download Dump</button>
                   </div>
                   <div v-if="selectedRequest.review_note" class="notice notice--info"><strong>Review note:</strong> {{ selectedRequest.review_note }}</div>
-                  <div v-if="selectedRequest.execute_error" class="notice notice--error"><strong>Execution error:</strong> {{ selectedRequest.execute_error }}</div>
+                  <div v-if="selectedRequest.execute_error" class="notice notice--error"><strong>Error:</strong> {{ selectedRequest.execute_error }}</div>
                 </div>
               </div>
             </div>
           </div>
         </section>
 
+        <!-- ══ DIRECT DOWNLOAD ══════════════════════════════════════════ -->
         <div v-if="activeTab === 'direct' && canDirectBackup" class="page-card bv-card">
           <div class="page-card__head">
             <div>
               <div class="page-card__title">Direct SQL Dump</div>
-              <div class="page-card__sub">Immediate backup download for users with backup management access.</div>
+              <div class="page-card__sub">Immediate backup download. Backup options above apply here too.</div>
             </div>
           </div>
           <div class="page-card__body bv-card-body">
             <select class="base-input" v-model.number="directConnId" @change="onDirectConnChange">
               <option :value="null">Select connection…</option>
-              <option v-for="c in connections" :key="c.id" :value="c.id">{{ c.name }}</option>
+              <option v-for="c in dbConnections" :key="c.id" :value="c.id">{{ c.name }}</option>
             </select>
             <select class="base-input" v-model="directDatabase" :disabled="!directConnId || databasesLoading">
               <option value="">Default database/schema</option>
               <option v-for="db in databases" :key="db" :value="db">{{ db }}</option>
             </select>
-            <button class="base-btn base-btn--primary" :disabled="!directConnId" @click="downloadDirectBackup">Download .sql</button>
+
+            <!-- reuse shared opts panel -->
+            <div class="bv-opts-header" @click="showAdvanced = !showAdvanced">
+              <div class="bv-section-label" style="border:none;padding:0;margin:0">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93A10 10 0 0 0 5 5.07M4.93 19.07A10 10 0 0 0 19 18.93"/></svg>
+                Backup Options
+              </div>
+              <div class="bv-opts-header__right">
+                <span class="bv-opts-summary">{{ backupOpts.sections === 'all' ? 'Full dump' : backupOpts.sections }}</span>
+                <svg :style="{ transform: showAdvanced ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+              </div>
+            </div>
+
+            <div v-if="showAdvanced" class="bv-opts-panel">
+              <div class="bv-opts-group">
+                <div class="bv-opts-group__label">Sections</div>
+                <div class="bv-sections-grid">
+                  <label v-for="s in [
+                    { v: 'all', label: 'All', sub: 'Schema + data + constraints' },
+                    { v: 'pre-data', label: 'Pre-data', sub: 'CREATE TABLE, sequences' },
+                    { v: 'data', label: 'Data', sub: 'INSERT statements only' },
+                    { v: 'post-data', label: 'Post-data', sub: 'Indexes, FK constraints' },
+                  ]" :key="s.v" class="bv-section-card" :class="{ 'is-active': backupOpts.sections === s.v }">
+                    <input type="radio" v-model="backupOpts.sections" :value="s.v" style="display:none" />
+                    <span class="bv-section-card__label">{{ s.label }}</span>
+                    <span class="bv-section-card__sub">{{ s.sub }}</span>
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            <button class="base-btn base-btn--primary" :disabled="!directConnId" @click="downloadDirectBackup">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+              Download .sql
+            </button>
           </div>
         </div>
 
+        <!-- ══ RESTORE ══════════════════════════════════════════════════ -->
         <div v-if="activeTab === 'restore' && canDirectBackup" class="page-card bv-card">
           <div class="page-card__head">
             <div>
@@ -420,21 +939,19 @@ onMounted(async () => {
             </div>
           </div>
           <div class="page-card__body bv-card-body">
-            <select class="base-input" v-model.number="restoreConnId" @change="onRestoreConnChange">
+            <select class="base-input" v-model.number="restoreConnId">
               <option :value="null">Select connection…</option>
-              <option v-for="c in connections" :key="c.id" :value="c.id">{{ c.name }}</option>
+              <option v-for="c in dbConnections" :key="c.id" :value="c.id">{{ c.name }}</option>
             </select>
-            <div class="bv-drop" @dragover.prevent @drop.prevent="(e) => { const f=e.dataTransfer?.files?.[0]; if(f) f.text().then(t=>restoreSQL=t) }">
+            <div class="bv-drop" @dragover.prevent @drop.prevent="(e) => { const f = e.dataTransfer?.files?.[0]; if (f) f.text().then(t => restoreSQL = t) }">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
               <span>Drop a .sql file here or</span>
-              <label class="bv-file-btn">
-                Browse
-                <input type="file" accept=".sql,.txt" style="display:none" @change="uploadFile" />
-              </label>
+              <label class="bv-file-btn">Browse <input type="file" accept=".sql,.txt" style="display:none" @change="uploadFile" /></label>
             </div>
             <div v-if="restoreSQL" class="bv-preview">
               <div class="bv-preview-header">
                 <span>{{ restoreSQL.split('\n').length }} lines loaded</span>
-                <button class="base-btn base-btn--ghost base-btn--sm" @click="restoreSQL=''">Clear</button>
+                <button class="base-btn base-btn--ghost base-btn--sm" @click="restoreSQL = ''">Clear</button>
               </div>
               <pre class="bv-preview-pre">{{ restoreSQL.slice(0, 500) }}{{ restoreSQL.length > 500 ? '\n…' : '' }}</pre>
             </div>
@@ -445,21 +962,30 @@ onMounted(async () => {
             </button>
           </div>
         </div>
+
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
+/* ── Layout ── */
+.bv-tabs { margin-bottom: 2px; }
+
+.bv-bucket-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 16px;
+  align-items: flex-start;
+}
+
 .bv-request-layout {
   display: grid;
   grid-template-columns: 360px minmax(0, 1fr);
   gap: 16px;
 }
 
-.bv-card {
-  padding: 20px;
-}
+.bv-card { padding: 20px; }
 
 .bv-card-body {
   display: flex;
@@ -467,10 +993,465 @@ onMounted(async () => {
   gap: 14px;
 }
 
-.bv-filter {
-  max-width: 180px;
+.bv-filter { max-width: 180px; }
+
+/* ── Section label ── */
+.bv-section-label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  padding-bottom: 2px;
+  border-bottom: 1px solid var(--border);
 }
 
+/* ── Connection picker grid ── */
+.bv-conn-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 8px;
+}
+
+.bv-conn-card {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 12px;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-body);
+  cursor: pointer;
+  transition: border-color 0.13s, background 0.13s, box-shadow 0.13s;
+  text-align: left;
+}
+
+.bv-conn-card:hover {
+  border-color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 5%, var(--bg-elevated));
+}
+
+.bv-conn-card.is-active {
+  border-color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 10%, var(--bg-elevated));
+  box-shadow: 0 0 0 3px var(--brand-ring);
+}
+
+.bv-conn-card__badge {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.bv-conn-card__info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+
+.bv-conn-card__name {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bv-conn-card.is-active .bv-conn-card__name { color: var(--brand); }
+
+.bv-conn-card__driver {
+  font-size: 10.5px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bv-conn-card__check {
+  color: var(--brand);
+  flex-shrink: 0;
+}
+
+/* ── Backup options panel ── */
+.bv-opts-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-body);
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  user-select: none;
+}
+
+.bv-opts-header:hover {
+  border-color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 4%, var(--bg-elevated));
+}
+
+.bv-opts-header__right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+}
+
+.bv-opts-summary {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  text-transform: capitalize;
+}
+
+.bv-opts-panel {
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-body);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.bv-opts-group {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.bv-opts-group:last-child { border-bottom: none; }
+
+.bv-opts-group__label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+/* Sections radio grid */
+.bv-sections-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 7px;
+}
+
+.bv-section-card {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 9px 11px;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s, box-shadow 0.12s;
+}
+
+.bv-section-card:hover { border-color: var(--brand); }
+
+.bv-section-card.is-active {
+  border-color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 10%, var(--bg-elevated));
+  box-shadow: 0 0 0 3px var(--brand-ring);
+}
+
+.bv-section-card__label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.bv-section-card.is-active .bv-section-card__label { color: var(--brand); }
+
+.bv-section-card__sub {
+  font-size: 10px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+/* Toggle rows */
+.bv-toggle-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.bv-toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 4px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.bv-toggle-row:hover { background: color-mix(in srgb, var(--brand) 4%, transparent); }
+
+.bv-toggle-row__name {
+  display: block;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.bv-toggle-row__desc {
+  display: block;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 1px;
+}
+
+/* Switch toggle */
+.bv-switch {
+  position: relative;
+  width: 34px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--border);
+  flex-shrink: 0;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.bv-switch.is-on { background: var(--brand); }
+
+.bv-switch__knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: white;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.25);
+}
+
+.bv-switch.is-on .bv-switch__knob { transform: translateX(16px); }
+
+/* Check pills */
+.bv-check-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.bv-check-pill {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 11px;
+  border: 1.5px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+
+.bv-check-pill svg { opacity: 0; transition: opacity 0.12s; }
+
+.bv-check-pill:hover { border-color: var(--brand); }
+
+.bv-check-pill.is-on {
+  border-color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 12%, var(--bg-elevated));
+  color: var(--brand);
+}
+
+.bv-check-pill.is-on svg { opacity: 1; }
+
+.bv-badge-sm {
+  font-size: 9px;
+  font-weight: 700;
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+
+/* ── Filename preview ── */
+.bv-preview-name {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--brand-dim);
+  border: 1px solid color-mix(in srgb, var(--brand) 20%, transparent);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--brand);
+  line-height: 1.5;
+}
+
+.bv-preview-name em { color: var(--text-muted); font-style: normal; }
+
+/* ── Run row ── */
+.bv-run-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+/* ── Result card ── */
+.bv-result-card {
+  border: 1px solid var(--success);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--success) 8%, transparent);
+  overflow: hidden;
+}
+
+.bv-result-card__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--success);
+  border-bottom: 1px solid color-mix(in srgb, var(--success) 20%, transparent);
+}
+
+.bv-result-card__rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.bv-result-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 8px 14px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  font-size: 12px;
+}
+
+.bv-result-row:last-child { border-bottom: none; }
+
+.bv-result-row__label {
+  min-width: 90px;
+  font-weight: 600;
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+
+.bv-result-row__val {
+  color: var(--text-primary);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  word-break: break-all;
+}
+
+/* ── History ── */
+.bv-history-card { min-height: 320px; }
+
+.bv-count-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 20px;
+  padding: 0 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  background: var(--brand-dim);
+  color: var(--brand);
+}
+
+.bv-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 4px;
+}
+
+.bv-history-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 9px 10px;
+  border-radius: 8px;
+  transition: background 0.1s;
+}
+
+.bv-history-item:hover { background: var(--bg-body); }
+
+.bv-history-item__icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: var(--bg-body);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.bv-history-item__body { flex: 1; min-width: 0; }
+
+.bv-history-item__key {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+  font-family: var(--mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bv-history-item__meta {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+/* ── Hints ── */
+.bv-hint-inline {
+  font-size: 10.5px;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin-left: 4px;
+}
+
+.bv-empty-hint {
+  font-size: 12.5px;
+  color: var(--text-muted);
+  padding: 12px 0;
+}
+
+/* ── Request section (unchanged styles) ── */
 .bv-request-grid {
   display: grid;
   grid-template-columns: 280px minmax(0, 1fr);
@@ -491,6 +1472,7 @@ onMounted(async () => {
   background: var(--bg-elevated);
   padding: 12px 14px;
   cursor: pointer;
+  transition: border-color 0.13s;
 }
 
 .bv-request-item--active {
@@ -510,18 +1492,11 @@ onMounted(async () => {
 }
 
 .bv-request-item__title,
-.bv-detail__title {
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--text-primary);
-}
+.bv-detail__title { font-size: 13px; font-weight: 700; color: var(--text-primary); }
 
 .bv-request-item__meta,
 .bv-detail__sub,
-.bv-meta {
-  font-size: 11px;
-  color: var(--text-muted);
-}
+.bv-meta { font-size: 11px; color: var(--text-muted); }
 
 .bv-detail-card {
   border: 1px solid var(--border);
@@ -533,16 +1508,8 @@ onMounted(async () => {
   gap: 12px;
 }
 
-.bv-description {
-  font-size: 12px;
-  color: var(--text-secondary);
-  line-height: 1.6;
-}
-
-.bv-note {
-  width: 100%;
-  min-height: 84px;
-}
+.bv-description { font-size: 12px; color: var(--text-secondary); line-height: 1.6; }
+.bv-note { width: 100%; min-height: 84px; }
 
 .bv-status {
   display: inline-flex;
@@ -557,29 +1524,23 @@ onMounted(async () => {
 }
 
 .bv-status[data-status="approved"],
-.bv-status[data-status="done"] {
-  background: rgba(34, 197, 94, 0.15);
-  color: #16a34a;
-}
+.bv-status[data-status="done"] { background: rgba(34, 197, 94, 0.15); color: #16a34a; }
 
 .bv-status[data-status="pending_review"],
-.bv-status[data-status="executing"] {
-  background: rgba(245, 158, 11, 0.16);
-  color: #d97706;
-}
+.bv-status[data-status="executing"] { background: rgba(245, 158, 11, 0.16); color: #d97706; }
 
 .bv-status[data-status="rejected"],
-.bv-status[data-status="failed"] {
-  background: rgba(239, 68, 68, 0.14);
-  color: #dc2626;
-}
+.bv-status[data-status="failed"] { background: rgba(239, 68, 68, 0.14); color: #dc2626; }
 
 .bv-empty {
-  padding: 18px;
-  border: 1px dashed var(--border);
-  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 32px 20px;
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 12.5px;
   text-align: center;
 }
 
@@ -597,9 +1558,7 @@ onMounted(async () => {
   transition: border-color 0.15s;
 }
 
-.bv-drop:hover {
-  border-color: var(--brand);
-}
+.bv-drop:hover { border-color: var(--brand); }
 
 .bv-file-btn {
   padding: 4px 12px;
@@ -639,41 +1598,29 @@ onMounted(async () => {
   word-break: break-all;
 }
 
-.notice {
-  border-radius: 10px;
-  padding: 10px 14px;
-  font-size: 12.5px;
-}
+.notice { border-radius: 10px; padding: 10px 14px; font-size: 12.5px; display: flex; align-items: center; gap: 8px; }
+.notice--ok { background: rgba(74, 222, 128, 0.1); border: 1px solid rgba(74, 222, 128, 0.3); color: #16a34a; }
+.notice--error { background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.25); color: #dc2626; }
+.notice--warn, .notice--info { background: rgba(245, 158, 11, 0.12); border: 1px solid rgba(245, 158, 11, 0.22); color: #b45309; }
 
-.notice--ok {
-  background: rgba(74, 222, 128, 0.1);
-  border: 1px solid rgba(74, 222, 128, 0.3);
-  color: #16a34a;
-}
-
-.notice--error {
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.25);
-  color: #dc2626;
-}
-
-.notice--warn,
-.notice--info {
-  background: rgba(245, 158, 11, 0.12);
-  border: 1px solid rgba(245, 158, 11, 0.22);
-  color: #b45309;
-}
-
+/* ── Responsive ── */
 @media (max-width: 1100px) {
   .bv-request-layout,
-  .bv-request-grid {
-    grid-template-columns: 1fr;
-  }
+  .bv-request-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 900px) {
+  .bv-bucket-layout { grid-template-columns: 1fr; }
+  .bv-sections-grid { grid-template-columns: repeat(2, 1fr); }
 }
 
 @media (max-width: 720px) {
-  .bv-card {
-    padding: 16px;
-  }
+  .bv-card { padding: 16px; }
+  .bv-conn-grid { grid-template-columns: 1fr 1fr; }
+}
+
+@media (max-width: 480px) {
+  .bv-conn-grid { grid-template-columns: 1fr; }
+  .bv-run-row { flex-direction: column; align-items: stretch; }
 }
 </style>

--- a/web/src/views/ConnectionsView.vue
+++ b/web/src/views/ConnectionsView.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { ref, reactive, onMounted } from 'vue'
+import { ref, reactive, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import axios from 'axios'
 import { useConnections, type DbDriver, type ConnectionForm } from '@/composables/useConnections'
 import { useFolders } from '@/composables/useFolders'
 import { useToast } from '@/composables/useToast'
 import { useConfirm } from '@/composables/useConfirm'
+import DriverIcon from '@/components/ui/DriverIcon.vue'
 
 const { connections, loading, testConnection, saveConnection, removeConnection, fetchConnections, disconnectConnection, reconnectConnection } = useConnections()
 const { folders, fetchFolders, moveConnection, setConnectionVisibility } = useFolders()
@@ -31,6 +32,25 @@ const defaultPorts: Record<DbDriver, number> = {
   redis: 6379,
   memcache: 11211,
   kafka: 9092,
+  s3_aws: 443,
+  s3_gcp: 443,
+  s3_oss: 443,
+  s3_obs: 443,
+}
+
+const defaultHosts: Record<DbDriver, string> = {
+  sqlite: 'localhost',
+  postgres: 'localhost',
+  mysql: 'localhost',
+  mariadb: 'localhost',
+  mssql: 'localhost',
+  redis: 'localhost',
+  memcache: 'localhost',
+  kafka: 'localhost',
+  s3_aws: 's3.us-east-1.amazonaws.com',
+  s3_gcp: 'storage.googleapis.com',
+  s3_oss: 'oss-cn-hangzhou.aliyuncs.com',
+  s3_obs: 'obs.ap-southeast-1.myhuaweicloud.com',
 }
 
 const form = reactive<ConnectionForm>({
@@ -57,7 +77,7 @@ type DriverOption = { key: DbDriver; label: string; badge: string; sub: string }
 const driverGroups: Array<{ key: string; label: string; options: DriverOption[] }> = [
   {
     key: 'rdbms',
-    label: 'RDBMS',
+    label: 'Relational',
     options: [
       { key: 'sqlite',   label: 'SQLite',     badge: 'SL',  sub: 'file' },
       { key: 'postgres', label: 'PostgreSQL', badge: 'PG',  sub: 'v12+' },
@@ -67,13 +87,8 @@ const driverGroups: Array<{ key: string; label: string; options: DriverOption[] 
     ],
   },
   {
-    key: 'nosql',
-    label: 'NoSQL',
-    options: [],
-  },
-  {
     key: 'cache',
-    label: 'Database Cache',
+    label: 'Cache',
     options: [
       { key: 'redis', label: 'Redis', badge: 'RD', sub: 'v6+' },
       { key: 'memcache', label: 'Memcache', badge: 'MC', sub: 'v1.6+' },
@@ -84,6 +99,16 @@ const driverGroups: Array<{ key: string; label: string; options: DriverOption[] 
     label: 'Streaming',
     options: [
       { key: 'kafka', label: 'Kafka', badge: 'KF', sub: 'v2+' },
+    ],
+  },
+  {
+    key: 'object-storage',
+    label: 'Object Storage',
+    options: [
+      { key: 's3_aws', label: 'AWS S3',         badge: 'S3',  sub: 'bucket' },
+      { key: 's3_gcp', label: 'GCP Storage',    badge: 'GCS', sub: 'S3 API' },
+      { key: 's3_oss', label: 'Alibaba OSS',    badge: 'OSS', sub: 'bucket' },
+      { key: 's3_obs', label: 'Huawei OBS',     badge: 'OBS', sub: 'bucket' },
     ],
   },
 ]
@@ -97,11 +122,98 @@ const defaultDatabases: Record<DbDriver, string> = {
   redis: '0',
   memcache: '',
   kafka: '',
+  s3_aws: '',
+  s3_gcp: '',
+  s3_oss: '',
+  s3_obs: '',
+}
+
+const driverDescriptions: Record<DbDriver, string> = {
+  sqlite:   'Serverless, file-based database — no server needed. Just point to a file path.',
+  postgres: 'Feature-rich open-source RDBMS. Fill in host, port, database name, username, and password.',
+  mysql:    "The world's most popular open-source relational database. Fill in host, port, database, username, and password.",
+  mariadb:  'Community-maintained MySQL fork. Configuration is identical to MySQL.',
+  mssql:    'Microsoft SQL Server. Uses host, port (1433), database, and Windows or SQL auth credentials.',
+  redis:    'In-memory key-value store. Only host, port, and an optional password are required. The "database" is a numeric index (0–15).',
+  memcache: 'Distributed memory caching — no authentication. Just a host and port.',
+  kafka:    'Distributed event streaming. Provide a broker host and port. SASL username/password are optional.',
+  s3_aws:   'Amazon S3 object storage. Provide your bucket name, endpoint, Access Key ID, and Secret Access Key.',
+  s3_gcp:   'Google Cloud Storage via the S3-compatible API. Endpoint, bucket, and service-account credentials are required.',
+  s3_oss:   'Alibaba Cloud OSS via the S3-compatible API. Provide your OSS endpoint, bucket, and access credentials.',
+  s3_obs:   'Huawei Cloud OBS via the S3-compatible API. Provide your OBS endpoint, bucket, and access credentials.',
+}
+
+// ── Computed driver flags ─────────────────────────────────────────
+const isSQLite    = computed(() => form.driver === 'sqlite')
+const isRedis     = computed(() => form.driver === 'redis')
+const isMemcache  = computed(() => form.driver === 'memcache')
+const isKafka     = computed(() => form.driver === 'kafka')
+const isS3        = computed(() => isObjectStorageDriver(form.driver))
+const isRDBMS     = computed(() => ['postgres', 'mysql', 'mariadb', 'mssql'].includes(form.driver))
+
+function isObjectStorageDriver(driver: DbDriver) {
+  return driver === 's3_aws' || driver === 's3_gcp' || driver === 's3_oss' || driver === 's3_obs'
+}
+
+function driverCategory(driver: DbDriver): string {
+  if (['postgres', 'mysql', 'mariadb', 'mssql', 'sqlite'].includes(driver)) return 'rdbms'
+  if (driver === 'redis' || driver === 'memcache') return 'cache'
+  if (driver === 'kafka') return 'streaming'
+  return 's3'
+}
+
+function categoryLabel(driver: DbDriver): string {
+  const cat = driverCategory(driver)
+  return { rdbms: 'Relational DB', cache: 'Cache', streaming: 'Streaming', s3: 'Object Storage' }[cat] ?? cat
+}
+
+function driverBadge(driver: DbDriver) {
+  return ({ sqlite: 'SL', postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD', memcache: 'MC', kafka: 'KF', s3_aws: 'S3', s3_gcp: 'GCS', s3_oss: 'OSS', s3_obs: 'OBS' } as Record<DbDriver, string>)[driver] ?? driver.slice(0, 2).toUpperCase()
+}
+
+function driverFullName(driver: DbDriver) {
+  return ({ sqlite: 'SQLite', postgres: 'PostgreSQL', mysql: 'MySQL', mariadb: 'MariaDB', mssql: 'SQL Server', redis: 'Redis', memcache: 'Memcache', kafka: 'Kafka', s3_aws: 'AWS S3', s3_gcp: 'GCP Storage', s3_oss: 'Alibaba OSS', s3_obs: 'Huawei OBS' } as Record<DbDriver, string>)[driver] ?? driver
+}
+
+function connDetailLine(conn: { driver: DbDriver; host: string; port: number; database: string; username: string }): string {
+  if (conn.driver === 'sqlite') return conn.database || '(no file path set)'
+  if (isObjectStorageDriver(conn.driver)) {
+    const bucket = conn.database || '(no bucket)'
+    return `${bucket}  ·  ${conn.host}`
+  }
+  if (conn.driver === 'memcache') {
+    return `${conn.host}${conn.port ? ':' + conn.port : ''}`
+  }
+  if (conn.driver === 'kafka') {
+    const sasl = conn.username ? `  ·  SASL: ${conn.username}` : ''
+    return `${conn.host}${conn.port ? ':' + conn.port : ''}${sasl}`
+  }
+  if (conn.driver === 'redis') {
+    const db = conn.database ? `  ·  db ${conn.database}` : '  ·  db 0'
+    return `${conn.host}${conn.port ? ':' + conn.port : ''}${db}`
+  }
+  // RDBMS
+  const user = conn.username ? `${conn.username}@` : ''
+  const db = conn.database ? `  ·  ${conn.database}` : ''
+  return `${user}${conn.host}${conn.port ? ':' + conn.port : ''}${db}`
+}
+
+function openConnectionLabel(driver: DbDriver): string {
+  if (driver === 'redis') return 'Browse'
+  if (driver === 'memcache') return 'Browse'
+  if (driver === 'kafka') return 'Browse'
+  if (isObjectStorageDriver(driver)) return 'Browse'
+  return 'Open'
 }
 
 function selectDriver(d: DbDriver) {
+  const previousDefaultHost = defaultHosts[form.driver]
   form.driver = d
   form.port = defaultPorts[d]
+  form.ssl = isObjectStorageDriver(d) ? true : form.ssl
+  if (!form.host || form.host === previousDefaultHost || form.host === 'localhost') {
+    form.host = defaultHosts[d]
+  }
   if (!form.database || Object.values(defaultDatabases).includes(form.database)) {
     form.database = defaultDatabases[d]
   }
@@ -132,7 +244,6 @@ function resetForm() {
 async function editConnection(id: number) {
   try {
     const { data: conn } = await axios.get(`/api/connections/${id}`)
-    
     editingId.value = id
     form.name = conn.name
     form.driver = conn.driver
@@ -152,15 +263,23 @@ async function editConnection(id: number) {
     form.visibility = conn.visibility || 'shared'
     testResult.value = null
     showForm.value = true
-  } catch (err) {
+  } catch {
     toast.error('Failed to load connection')
   }
 }
 
 function validateForm(): string | null {
   if (!form.name.trim()) return 'Connection name is required'
+  if (isObjectStorageDriver(form.driver)) {
+    if (!form.host.trim()) return 'Endpoint host is required'
+    if (!form.database.trim()) return 'Bucket name is required'
+    if (!form.username.trim()) return 'Access key is required'
+    if (!form.password.trim()) return 'Secret key is required'
+  }
   const needsDb = ['sqlite', 'postgres', 'mysql', 'mariadb', 'mssql']
-  if (needsDb.includes(form.driver) && !form.database.trim()) return form.driver === 'sqlite' ? 'SQLite file path is required' : 'Database name is required'
+  if (needsDb.includes(form.driver) && !form.database.trim()) {
+    return form.driver === 'sqlite' ? 'SQLite file path is required' : 'Database name is required'
+  }
   return null
 }
 
@@ -176,35 +295,24 @@ async function handleTest() {
 async function handleSave() {
   const err = validateForm()
   if (err) { toast.error(err); return }
-  
   saving.value = true
   let conn
-  
   if (editingId.value) {
-    // Update existing connection
     try {
       const { data } = await axios.put(`/api/connections/${editingId.value}`, form)
       conn = data
       await fetchConnections()
       toast.success(`Connection "${conn.name}" updated`)
-    } catch (err) {
+    } catch {
       toast.error('Failed to update connection')
     }
   } else {
-    // Create new connection
     conn = await saveConnection({ ...form })
-    if (conn) {
-      toast.success(`Connection "${conn.name}" saved`)
-    } else {
-      toast.error('Failed to save connection')
-    }
+    if (conn) toast.success(`Connection "${conn.name}" saved`)
+    else toast.error('Failed to save connection')
   }
-  
   saving.value = false
-  if (conn) {
-    showForm.value = false
-    resetForm()
-  }
+  if (conn) { showForm.value = false; resetForm() }
 }
 
 // ── URL import ────────────────────────────────────────────────────
@@ -222,6 +330,10 @@ function parseConnectionURL(raw: string) {
       redis: 'redis', rediss: 'redis',
       memcache: 'memcache', memcached: 'memcache',
       kafka: 'kafka',
+      s3: 's3_aws', s3a: 's3_aws',
+      gcs: 's3_gcp', gs: 's3_gcp',
+      oss: 's3_oss',
+      obs: 's3_obs',
     }
     const driver = driverMap[scheme] ?? ('postgres' as DbDriver)
     form.driver = driver
@@ -231,26 +343,24 @@ function parseConnectionURL(raw: string) {
     form.username = decodeURIComponent(url.username || '')
     form.password = decodeURIComponent(url.password || '')
     form.ssl = scheme === 'rediss' || url.searchParams.get('sslmode') === 'require' || url.searchParams.get('ssl') === 'true'
-    if (!form.name) form.name = driver === 'kafka' || driver === 'memcache' ? `${driver} / ${form.host}` : `${driver} / ${form.database}`
+    if (!form.name) {
+      form.name = driver === 'kafka' || driver === 'memcache'
+        ? `${driver} / ${form.host}`
+        : isObjectStorageDriver(driver)
+          ? `${driverFullName(driver)} / ${form.database || form.host}`
+          : `${driver} / ${form.database}`
+    }
     showURLImport.value = false
     urlInput.value = ''
     testResult.value = null
   } catch {
-    // ignore parse errors - let user fix the URL
+    // ignore parse errors
   }
-}
-
-function driverBadge(driver: DbDriver) {
-  return ({ sqlite: 'SL', postgres: 'PG', mysql: 'MY', mariadb: 'MB', mssql: 'MS', redis: 'RD', memcache: 'MC', kafka: 'KF' } as Record<DbDriver, string>)[driver] ?? driver.slice(0, 2).toUpperCase()
-}
-
-function driverFullName(driver: DbDriver) {
-  return ({ sqlite: 'SQLite', postgres: 'PostgreSQL', mysql: 'MySQL', mariadb: 'MariaDB', mssql: 'SQL Server', redis: 'Redis', memcache: 'Memcache', kafka: 'Kafka' } as Record<DbDriver, string>)[driver] ?? driver
 }
 
 function openConnection(id: number, driver: DbDriver) {
   emit('set-conn', id)
-  router.push({ name: driver === 'redis' ? 'redis' : driver === 'memcache' ? 'memcache' : driver === 'kafka' ? 'kafka' : 'data' })
+  router.push({ name: driver === 'redis' ? 'redis' : driver === 'memcache' ? 'memcache' : driver === 'kafka' ? 'kafka' : isObjectStorageDriver(driver) ? 'connections' : 'data' })
 }
 
 async function handleDelete(id: number, name: string) {
@@ -278,11 +388,13 @@ async function handleReconnect(id: number, name: string) {
   <div class="page-shell conn-page">
     <div class="page-scroll">
       <div class="page-stack">
+
+        <!-- Hero -->
         <section class="page-hero">
           <div class="page-hero__content">
             <div class="page-kicker">Infrastructure</div>
             <div class="page-title">Connections</div>
-            <div class="page-subtitle">Add, organize, and validate the database endpoints your team works against every day.</div>
+            <div class="page-subtitle">Add, organize, and test your database and service endpoints.</div>
           </div>
           <div class="page-hero__actions">
             <button class="base-btn base-btn--primary base-btn--sm" @click="resetForm(); showForm = true">
@@ -292,293 +404,474 @@ async function handleReconnect(id: number, name: string) {
           </div>
         </section>
 
-        <div class="conn-layout">
-      <!-- Connection list -->
-      <section class="page-panel conn-list">
-        <div class="conn-list__head">
-          <div>
-            <div class="conn-list__title">Connection Library</div>
-            <div class="conn-list__sub">{{ connections.length }} saved endpoints</div>
-          </div>
-        </div>
-        <div v-if="loading" style="display:flex;align-items:center;gap:8px;color:var(--text-muted);font-size:13px;padding:20px">
-          <svg class="spin" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
-          Loading connections…
-        </div>
-
-        <div v-else-if="connections.length === 0" class="empty-state" style="padding:40px 0">
-          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="color:var(--text-muted)"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg>
-          No connections yet. Add your first one.
-        </div>
-
-        <div v-else class="conn-list">
-          <div
-            v-for="conn in connections"
-            :key="conn.id"
-            class="conn-row"
-          >
-            <!-- Driver badge -->
-            <div class="conn-badge conn-row__badge" :class="`conn-badge--${conn.driver}`">
-              {{ driverBadge(conn.driver) }}
-            </div>
-
-            <!-- Main info -->
-            <div class="conn-row__body">
-              <div class="conn-row__top">
-                <span class="conn-row__name">{{ conn.name }}</span>
-                <span class="conn-row__driver">{{ driverFullName(conn.driver) }}</span>
-                <span class="conn-row__vis" :title="conn.visibility">{{ conn.visibility === 'shared' ? '🌐' : '🔒' }}</span>
-              </div>
-              <div class="conn-row__host">
-                {{ conn.username ? `${conn.username}@` : '' }}{{ conn.host }}{{ conn.port ? `:${conn.port}` : '' }}{{ (conn.driver === 'redis' ? `/db${conn.database || 0}` : conn.driver === 'memcache' ? '' : conn.database ? `/${conn.database}` : '') }}
-              </div>
-              <div v-if="conn.folder_id" class="conn-row__folder">
-                {{ folders.find(f => f.id === conn.folder_id)?.name ?? 'Folder' }}
-              </div>
-            </div>
-
-            <!-- Actions -->
-            <div class="conn-row__actions">
-              <button
-                class="base-btn base-btn--sm"
-                :class="conn.disconnected ? 'base-btn--secondary' : 'base-btn--primary'"
-                :disabled="conn.disconnected"
-                :title="conn.disconnected ? 'Connection is disconnected' : ''"
-                @click="openConnection(conn.id, conn.driver)"
-              >
-                {{ conn.disconnected ? 'Disconnected' : 'Open' }}
-              </button>
-              <select
-                :value="conn.folder_id ?? ''"
-                class="conn-row__folder-sel"
-                title="Move to folder"
-                @change="moveConnection(conn.id, ($event.target as HTMLSelectElement).value ? Number(($event.target as HTMLSelectElement).value) : null)"
-              >
-                <option value="">📂 Unfiled</option>
-                <option v-for="f in folders" :key="f.id" :value="f.id">{{ f.name }}</option>
-              </select>
-              <button
-                class="icon-btn"
-                :title="conn.visibility === 'shared' ? 'Make private' : 'Make shared'"
-                @click="setConnectionVisibility(conn.id, conn.visibility === 'shared' ? 'private' : 'shared').then(() => fetchConnections())"
-              >
-                <svg v-if="conn.visibility === 'shared'" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-                <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-              </button>
-              <button class="icon-btn" @click="editConnection(conn.id)" title="Edit">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
-              </button>
-              <button
-                v-if="!conn.disconnected"
-                class="icon-btn"
-                title="Disconnect"
-                @click="handleDisconnect(conn.id, conn.name)"
-              >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg>
-              </button>
-              <button
-                v-else
-                class="icon-btn"
-                style="color: var(--color-success, #22c55e)"
-                title="Reconnect"
-                @click="handleReconnect(conn.id, conn.name)"
-              >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
-              </button>
-              <button class="icon-btn danger" @click="handleDelete(conn.id, conn.name)" title="Delete">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>
-              </button>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- Add connection form -->
-      <Transition name="modal">
-        <div
-          v-if="showForm"
-          class="conn-form page-panel"
-        >
-          <div class="modal-hd">
-            <span class="modal-title">{{ editingId ? 'Edit Connection' : 'New Connection' }}</span>
-            <button class="icon-btn" @click="showForm = false; resetForm()">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-            </button>
-          </div>
-
-          <div class="modal-bd">
-            <!-- URL import -->
-            <div class="form-group">
-              <button class="base-btn base-btn--ghost base-btn--sm" style="width:100%;justify-content:center" @click="showURLImport = !showURLImport">
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
-                Import from URL
-              </button>
-              <div v-if="showURLImport" style="margin-top:8px;display:flex;gap:6px">
-                <input
-                  v-model="urlInput"
-                  class="base-input"
-                  placeholder="postgres://user:pass@host:5432/dbname, redis://host:6379/0, memcache://host:11211, or kafka://broker:9092"
-                  style="flex:1;font-family:var(--font-mono);font-size:11px"
-                  @keydown.enter="parseConnectionURL(urlInput)"
-                />
-                <button class="base-btn base-btn--primary base-btn--sm" @click="parseConnectionURL(urlInput)">Parse</button>
-              </div>
-            </div>
-
-            <!-- Driver selection -->
-            <div class="form-group">
-              <label class="form-label">Database Engine</label>
-              <div class="provider-groups">
-                <div v-for="group in driverGroups" :key="group.key" class="provider-group">
-                  <div class="provider-group__head">
-                    <span>{{ group.label }}</span>
-                    <span>{{ group.options.length }}</span>
-                  </div>
-                  <div v-if="group.options.length" class="provider-grid">
-                    <button
-                      v-for="d in group.options"
-                      :key="d.key"
-                      class="provider-card"
-                      :class="[`provider-card--${d.key}`, { 'is-active': form.driver === d.key }]"
-                      @click="selectDriver(d.key)"
-                    >
-                      <div class="provider-card__icon" :class="`provider-card__icon--${d.key}`">{{ d.badge }}</div>
-                      <div class="provider-card__body">
-                        <span class="provider-card__name">{{ d.label }}</span>
-                        <span class="provider-card__sub">{{ d.sub }}</span>
-                      </div>
-                      <svg v-if="form.driver === d.key" class="provider-card__check" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
-                    </button>
-                  </div>
-                  <div v-else class="provider-group__empty">No drivers yet</div>
-                </div>
-              </div>
-            </div>
-
-            <div class="form-group">
-              <label class="form-label">Connection Name</label>
-              <input v-model="form.name" class="base-input" placeholder="My Database" />
-            </div>
-
+        <!-- Connection List -->
+        <section class="page-panel conn-panel">
+          <div class="conn-panel__head">
             <div>
-              <div class="form-row">
-                <div class="form-group" style="flex:2">
-                  <label class="form-label">Host</label>
-                  <input v-model="form.host" class="base-input" placeholder="localhost" />
-                </div>
-                <div class="form-group" style="flex:1">
-                  <label class="form-label">Port</label>
-                  <input v-model.number="form.port" class="base-input" type="number" />
-                </div>
-              </div>
-
-              <div class="form-group">
-              <label class="form-label">{{ form.driver === 'redis' ? 'Database Index' : form.driver === 'memcache' ? 'Namespace / Notes' : form.driver === 'kafka' ? 'Client ID / Notes' : 'Database' }}</label>
-                <input v-model="form.database" class="base-input" :placeholder="defaultDatabases[form.driver] || (form.driver === 'kafka' || form.driver === 'memcache' ? 'optional' : 'required')" />
-              </div>
-
-              <div class="form-row">
-                <div class="form-group">
-                  <label class="form-label">Username</label>
-                  <input v-model="form.username" class="base-input" :placeholder="form.driver === 'redis' ? 'default' : form.driver === 'memcache' ? 'unused' : form.driver === 'kafka' ? 'SASL username' : 'postgres'" />
-                </div>
-                <div class="form-group">
-                  <label class="form-label">Password</label>
-                  <input v-model="form.password" class="base-input" type="password" placeholder="••••••••" />
-                </div>
-              </div>
-
-              <div style="display:flex;align-items:center;gap:8px">
-                <input id="ssl" type="checkbox" v-model="form.ssl" style="accent-color:var(--brand)" />
-                <label for="ssl" class="form-label" style="cursor:pointer;margin:0">Enable SSL/TLS</label>
-              </div>
-            </div>
-
-            <!-- SSH Tunnel -->
-            <details class="ssh-section">
-              <summary class="ssh-summary">
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="11" width="20" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-                SSH Tunnel (optional)
-              </summary>
-              <div class="ssh-fields">
-                <div class="form-group">
-                  <label class="form-label">SSH Host</label>
-                  <input v-model="form.ssh_host" class="base-input" placeholder="bastion.example.com" />
-                </div>
-                <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px">
-                  <div class="form-group">
-                    <label class="form-label">SSH Port</label>
-                    <input v-model.number="form.ssh_port" class="base-input" type="number" placeholder="22" />
-                  </div>
-                  <div class="form-group">
-                    <label class="form-label">SSH User</label>
-                    <input v-model="form.ssh_user" class="base-input" placeholder="ubuntu" />
-                  </div>
-                </div>
-                <div class="form-group">
-                  <label class="form-label">SSH Password</label>
-                  <input v-model="form.ssh_password" class="base-input" type="password" placeholder="••••••••" />
-                </div>
-                <div class="form-group">
-                  <label class="form-label">SSH Private Key <span class="form-hint" style="display:inline">(PEM, optional)</span></label>
-                  <textarea v-model="form.ssh_key" class="base-input" rows="3" placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;..." style="font-family:monospace;font-size:11px;resize:vertical" />
-                </div>
-              </div>
-            </details>
-
-            <!-- Tags -->
-            <div class="form-group">
-              <label class="form-label">Tags <span class="form-hint" style="display:inline">(comma-separated, e.g. "Production, Analytics")</span></label>
-              <input v-model="form.tags" class="base-input" placeholder="Production, Analytics" />
-            </div>
-
-            <!-- Folder & Visibility -->
-            <div class="form-group">
-              <label class="form-label">Folder</label>
-              <select v-model="form.folder_id" class="base-input">
-                <option :value="null">No folder (Unfiled)</option>
-                <option v-for="f in folders" :key="f.id" :value="f.id">
-                  {{ f.visibility === 'shared' ? '🌐' : '🔒' }} {{ f.name }}
-                </option>
-              </select>
-            </div>
-            <div class="form-group">
-              <label class="form-label">Visibility</label>
-              <div style="display:flex;gap:8px">
-                <label class="vis-radio" :class="{ active: form.visibility === 'shared' }">
-                  <input type="radio" v-model="form.visibility" value="shared" style="display:none" />
-                  🌐 Shared <span class="form-hint" style="display:inline">— visible to all users</span>
-                </label>
-                <label class="vis-radio" :class="{ active: form.visibility === 'private' }">
-                  <input type="radio" v-model="form.visibility" value="private" style="display:none" />
-                  🔒 Private <span class="form-hint" style="display:inline">— only you</span>
-                </label>
-              </div>
-            </div>
-
-            <!-- Test result -->
-            <div v-if="testResult" class="notice" :class="testResult.ok ? 'notice--success' : 'notice--error'">
-              <svg v-if="testResult.ok" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
-              <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-              {{ testResult.message }}
+              <div class="conn-panel__title">Saved Connections</div>
+              <div class="conn-panel__sub">{{ connections.length }} endpoint{{ connections.length !== 1 ? 's' : '' }}</div>
             </div>
           </div>
 
-          <div class="modal-ft">
-            <button class="base-btn base-btn--ghost base-btn--sm" :disabled="testing" @click="handleTest">
-              <svg v-if="testing" class="spin" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
-              {{ testing ? 'Testing…' : 'Test' }}
+          <!-- Loading -->
+          <div v-if="loading" class="conn-loading">
+            <svg class="spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+            Loading connections…
+          </div>
+
+          <!-- Empty state -->
+          <div v-else-if="connections.length === 0" class="conn-empty">
+            <div class="conn-empty__icon">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4.03 3-9 3S3 13.66 3 12"/><path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5"/></svg>
+            </div>
+            <div class="conn-empty__title">No connections yet</div>
+            <div class="conn-empty__sub">Add your first connection to get started. Supports PostgreSQL, MySQL, Redis, Kafka, S3 and more.</div>
+            <button class="base-btn base-btn--primary base-btn--sm" style="margin-top:4px" @click="resetForm(); showForm = true">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              Add First Connection
             </button>
-            <button class="base-btn base-btn--primary base-btn--sm" :disabled="saving" @click="handleSave">
-              <svg v-if="saving" class="spin" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
-              {{ saving ? (editingId ? 'Updating…' : 'Saving…') : (editingId ? 'Update Connection' : 'Save Connection') }}
-            </button>
+          </div>
+
+          <!-- Connection cards -->
+          <div v-else class="conn-items">
+            <div
+              v-for="conn in connections"
+              :key="conn.id"
+              class="conn-card"
+              :class="[`conn-card--${driverCategory(conn.driver)}`, { 'conn-card--disconnected': conn.disconnected }]"
+            >
+              <!-- Driver badge -->
+              <div class="conn-card__badge conn-badge" :class="`conn-badge--${conn.driver}`">
+                <DriverIcon :driver="conn.driver" :size="22" />
+              </div>
+
+              <!-- Main info -->
+              <div class="conn-card__body">
+                <div class="conn-card__title-row">
+                  <span class="conn-card__name">{{ conn.name }}</span>
+                  <span class="conn-card__driver-tag">{{ driverFullName(conn.driver) }}</span>
+                  <span class="conn-card__category-tag">{{ categoryLabel(conn.driver) }}</span>
+                  <span class="conn-card__vis" :title="conn.visibility === 'shared' ? 'Shared' : 'Private'">
+                    {{ conn.visibility === 'shared' ? '🌐' : '🔒' }}
+                  </span>
+                </div>
+                <div class="conn-card__detail">{{ connDetailLine(conn) }}</div>
+                <div class="conn-card__meta-row">
+                  <span v-if="conn.folder_id" class="conn-card__folder">
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+                    {{ folders.find(f => f.id === conn.folder_id)?.name ?? 'Folder' }}
+                  </span>
+                  <span v-if="conn.tags" class="conn-card__tags">
+                    <span v-for="tag in conn.tags.split(',').filter((t: string) => t.trim())" :key="tag" class="conn-tag">{{ tag.trim() }}</span>
+                  </span>
+                  <span v-if="conn.ssl" class="conn-card__ssl-badge">SSL</span>
+                  <span v-if="conn.ssh_host" class="conn-card__ssh-badge">SSH</span>
+                </div>
+              </div>
+
+              <!-- Status + actions -->
+              <div class="conn-card__right">
+                <div class="conn-card__status">
+                  <span v-if="conn.disconnected" class="conn-status conn-status--off">Disconnected</span>
+                  <span v-else class="conn-status conn-status--on">Connected</span>
+                </div>
+                <div class="conn-card__actions">
+                  <button
+                    class="base-btn base-btn--sm"
+                    :class="conn.disconnected ? 'base-btn--ghost' : 'base-btn--primary'"
+                    :disabled="conn.disconnected"
+                    :title="conn.disconnected ? 'Reconnect first to open' : `Open in ${driverFullName(conn.driver)} view`"
+                    @click="openConnection(conn.id, conn.driver)"
+                  >
+                    {{ conn.disconnected ? 'Offline' : openConnectionLabel(conn.driver) }}
+                  </button>
+
+                  <select
+                    :value="conn.folder_id ?? ''"
+                    class="conn-card__folder-sel"
+                    title="Move to folder"
+                    @change="moveConnection(conn.id, ($event.target as HTMLSelectElement).value ? Number(($event.target as HTMLSelectElement).value) : null)"
+                  >
+                    <option value="">📂 Unfiled</option>
+                    <option v-for="f in folders" :key="f.id" :value="f.id">{{ f.name }}</option>
+                  </select>
+
+                  <button class="icon-btn" title="Edit connection" @click="editConnection(conn.id)">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                  </button>
+
+                  <button
+                    v-if="!conn.disconnected"
+                    class="icon-btn"
+                    title="Disconnect"
+                    @click="handleDisconnect(conn.id, conn.name)"
+                  >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18.36 6.64a9 9 0 1 1-12.73 0"/><line x1="12" y1="2" x2="12" y2="12"/></svg>
+                  </button>
+                  <button
+                    v-else
+                    class="icon-btn"
+                    style="color: var(--success)"
+                    title="Reconnect"
+                    @click="handleReconnect(conn.id, conn.name)"
+                  >
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+                  </button>
+
+                  <button class="icon-btn danger" title="Delete connection" @click="handleDelete(conn.id, conn.name)">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+      </div>
+    </div>
+
+    <!-- Form Modal -->
+    <Teleport to="body">
+      <Transition name="conn-modal">
+        <div v-if="showForm" class="conn-modal-backdrop" @click.self="showForm = false; resetForm()">
+          <div class="conn-modal-shell">
+
+            <!-- Header -->
+            <div class="conn-modal-head">
+              <div class="conn-modal-head__left">
+                <span class="conn-modal-title">{{ editingId ? 'Edit Connection' : 'New Connection' }}</span>
+                <span v-if="editingId" class="conn-modal-subtitle">Modifying an existing endpoint</span>
+                <span v-else class="conn-modal-subtitle">Configure your new endpoint</span>
+              </div>
+              <button class="icon-btn" @click="showForm = false; resetForm()">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              </button>
+            </div>
+
+            <!-- Body -->
+            <div class="conn-modal-body">
+
+              <!-- URL import -->
+              <div class="form-group">
+                <button class="base-btn base-btn--ghost base-btn--sm url-import-btn" @click="showURLImport = !showURLImport">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+                  Import from connection URL
+                </button>
+                <div v-if="showURLImport" class="url-import-row">
+                  <input
+                    v-model="urlInput"
+                    class="base-input"
+                    placeholder="postgres://user:pass@host:5432/dbname  ·  redis://host:6379  ·  s3://access:secret@endpoint/bucket"
+                    style="flex:1;font-family:var(--mono);font-size:11px"
+                    @keydown.enter="parseConnectionURL(urlInput)"
+                  />
+                  <button class="base-btn base-btn--primary base-btn--sm" @click="parseConnectionURL(urlInput)">Parse</button>
+                </div>
+              </div>
+
+              <!-- Step 1: Choose provider -->
+              <div class="form-section">
+                <div class="form-section__label">
+                  <span class="form-section__num">1</span>
+                  Choose provider
+                </div>
+                <div class="provider-groups">
+                  <div v-for="group in driverGroups" :key="group.key" class="provider-group">
+                    <div class="provider-group__head">{{ group.label }}</div>
+                    <div class="provider-grid">
+                      <button
+                        v-for="d in group.options"
+                        :key="d.key"
+                        class="provider-card"
+                        :class="[`provider-card--${d.key}`, { 'is-active': form.driver === d.key }]"
+                        @click="selectDriver(d.key)"
+                      >
+                        <div class="provider-card__icon" :class="`provider-card__icon--${d.key}`">
+                          <DriverIcon :driver="d.key" :size="16" />
+                        </div>
+                        <div class="provider-card__body">
+                          <span class="provider-card__name">{{ d.label }}</span>
+                          <span class="provider-card__sub">{{ d.sub }}</span>
+                        </div>
+                        <svg v-if="form.driver === d.key" class="provider-card__check" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Driver description hint -->
+                <div class="driver-hint">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+                  <span>{{ driverDescriptions[form.driver] }}</span>
+                </div>
+              </div>
+
+              <!-- Step 2: Connection details -->
+              <div class="form-section">
+                <div class="form-section__label">
+                  <span class="form-section__num">2</span>
+                  Connection details
+                </div>
+
+                <!-- Connection name (always shown) -->
+                <div class="form-group">
+                  <label class="form-label">Connection Name</label>
+                  <input v-model="form.name" class="base-input" placeholder="e.g. Production DB, Local Redis, Dev S3" />
+                </div>
+
+                <!-- ── SQLite ─────────────────────────────────────────── -->
+                <template v-if="isSQLite">
+                  <div class="form-group">
+                    <label class="form-label">Database File Path</label>
+                    <input v-model="form.database" class="base-input" placeholder="/path/to/nias.db" />
+                    <div class="form-hint">Absolute or relative path to the .db file. The file will be created if it doesn't exist.</div>
+                  </div>
+                </template>
+
+                <!-- ── Object Storage (S3 / GCS / OSS / OBS) ──────────── -->
+                <template v-else-if="isS3">
+                  <div class="form-group">
+                    <label class="form-label">Endpoint Host</label>
+                    <input v-model="form.host" class="base-input" :placeholder="defaultHosts[form.driver]" />
+                    <div class="form-hint">The S3-compatible endpoint URL (without https://).</div>
+                  </div>
+                  <div class="form-group">
+                    <label class="form-label">Bucket</label>
+                    <input v-model="form.database" class="base-input" placeholder="my-bucket-name" />
+                  </div>
+                  <div class="form-row">
+                    <div class="form-group">
+                      <label class="form-label">Access Key ID</label>
+                      <input v-model="form.username" class="base-input" placeholder="AKIAIOSFODNN7EXAMPLE" autocomplete="off" />
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">Secret Access Key</label>
+                      <input v-model="form.password" class="base-input" type="password" placeholder="••••••••" />
+                    </div>
+                  </div>
+                  <div class="field-note field-note--info">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                    SSL/TLS is always enabled for object storage.
+                  </div>
+                </template>
+
+                <!-- ── Memcache ─────────────────────────────────────────── -->
+                <template v-else-if="isMemcache">
+                  <div class="form-row">
+                    <div class="form-group" style="flex:2">
+                      <label class="form-label">Host</label>
+                      <input v-model="form.host" class="base-input" placeholder="localhost" />
+                    </div>
+                    <div class="form-group" style="flex:1">
+                      <label class="form-label">Port</label>
+                      <input v-model.number="form.port" class="base-input" type="number" />
+                    </div>
+                  </div>
+                  <div class="field-note">
+                    Memcache does not support authentication. Only host and port are needed.
+                  </div>
+                </template>
+
+                <!-- ── Redis ──────────────────────────────────────────────── -->
+                <template v-else-if="isRedis">
+                  <div class="form-row">
+                    <div class="form-group" style="flex:2">
+                      <label class="form-label">Host</label>
+                      <input v-model="form.host" class="base-input" placeholder="localhost" />
+                    </div>
+                    <div class="form-group" style="flex:1">
+                      <label class="form-label">Port</label>
+                      <input v-model.number="form.port" class="base-input" type="number" />
+                    </div>
+                  </div>
+                  <div class="form-row">
+                    <div class="form-group">
+                      <label class="form-label">
+                        Password
+                        <span class="field-optional">optional</span>
+                      </label>
+                      <input v-model="form.password" class="base-input" type="password" placeholder="(leave blank if none)" />
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">
+                        Database Index
+                        <span class="field-optional">0 – 15</span>
+                      </label>
+                      <input v-model="form.database" class="base-input" placeholder="0" />
+                    </div>
+                  </div>
+                  <div class="field-check-row">
+                    <input id="redis-ssl" type="checkbox" v-model="form.ssl" style="accent-color:var(--brand)" />
+                    <label for="redis-ssl" class="field-check-label">Enable SSL/TLS <span class="field-optional">(uses rediss:// scheme)</span></label>
+                  </div>
+                </template>
+
+                <!-- ── Kafka ──────────────────────────────────────────────── -->
+                <template v-else-if="isKafka">
+                  <div class="form-row">
+                    <div class="form-group" style="flex:2">
+                      <label class="form-label">Broker Host</label>
+                      <input v-model="form.host" class="base-input" placeholder="localhost" />
+                    </div>
+                    <div class="form-group" style="flex:1">
+                      <label class="form-label">Port</label>
+                      <input v-model.number="form.port" class="base-input" type="number" />
+                    </div>
+                  </div>
+                  <div class="form-row">
+                    <div class="form-group">
+                      <label class="form-label">
+                        SASL Username
+                        <span class="field-optional">optional</span>
+                      </label>
+                      <input v-model="form.username" class="base-input" placeholder="(leave blank if no auth)" />
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">
+                        SASL Password
+                        <span class="field-optional">optional</span>
+                      </label>
+                      <input v-model="form.password" class="base-input" type="password" placeholder="(leave blank if no auth)" />
+                    </div>
+                  </div>
+                  <div class="field-check-row">
+                    <input id="kafka-ssl" type="checkbox" v-model="form.ssl" style="accent-color:var(--brand)" />
+                    <label for="kafka-ssl" class="field-check-label">Enable SSL/TLS</label>
+                  </div>
+                </template>
+
+                <!-- ── Relational DB (postgres / mysql / mariadb / mssql) ── -->
+                <template v-else>
+                  <div class="form-row">
+                    <div class="form-group" style="flex:2">
+                      <label class="form-label">Host</label>
+                      <input v-model="form.host" class="base-input" placeholder="localhost" />
+                    </div>
+                    <div class="form-group" style="flex:1">
+                      <label class="form-label">Port</label>
+                      <input v-model.number="form.port" class="base-input" type="number" />
+                    </div>
+                  </div>
+                  <div class="form-group">
+                    <label class="form-label">Database</label>
+                    <input v-model="form.database" class="base-input" :placeholder="defaultDatabases[form.driver] || 'database_name'" />
+                  </div>
+                  <div class="form-row">
+                    <div class="form-group">
+                      <label class="form-label">Username</label>
+                      <input v-model="form.username" class="base-input" placeholder="postgres" autocomplete="off" />
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">Password</label>
+                      <input v-model="form.password" class="base-input" type="password" placeholder="••••••••" />
+                    </div>
+                  </div>
+                  <div class="field-check-row">
+                    <input id="rdbms-ssl" type="checkbox" v-model="form.ssl" style="accent-color:var(--brand)" />
+                    <label for="rdbms-ssl" class="field-check-label">Enable SSL/TLS</label>
+                  </div>
+                </template>
+              </div>
+
+              <!-- Step 3: Advanced -->
+              <details class="conn-advanced">
+                <summary class="conn-advanced__trigger">
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93A10 10 0 0 0 5 5.07M4.93 19.07A10 10 0 0 0 19 18.93M2 12h1m18 0h1M12 2v1m0 18v1M6.34 17.66l-.7.7m11.32-11.32.7.7M6.34 6.34l-.7-.7m11.32 11.32.7.7"/></svg>
+                  Advanced options
+                  <span class="conn-advanced__hint">SSH tunnel, tags, folder, visibility</span>
+                </summary>
+                <div class="conn-advanced__body">
+
+                  <!-- SSH Tunnel -->
+                  <div class="adv-section">
+                    <div class="adv-section__label">SSH Tunnel <span class="field-optional">optional</span></div>
+                    <div class="form-group">
+                      <label class="form-label">SSH Host</label>
+                      <input v-model="form.ssh_host" class="base-input" placeholder="bastion.example.com" />
+                    </div>
+                    <div class="form-row">
+                      <div class="form-group">
+                        <label class="form-label">SSH Port</label>
+                        <input v-model.number="form.ssh_port" class="base-input" type="number" placeholder="22" />
+                      </div>
+                      <div class="form-group">
+                        <label class="form-label">SSH User</label>
+                        <input v-model="form.ssh_user" class="base-input" placeholder="ubuntu" />
+                      </div>
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">SSH Password</label>
+                      <input v-model="form.ssh_password" class="base-input" type="password" placeholder="••••••••" />
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">SSH Private Key <span class="field-optional">PEM, optional</span></label>
+                      <textarea v-model="form.ssh_key" class="base-input" rows="3" placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;..." style="font-family:monospace;font-size:11px;resize:vertical" />
+                    </div>
+                  </div>
+
+                  <!-- Tags -->
+                  <div class="form-group">
+                    <label class="form-label">Tags <span class="field-optional">comma-separated</span></label>
+                    <input v-model="form.tags" class="base-input" placeholder="Production, Analytics, Reporting" />
+                  </div>
+
+                  <!-- Folder & Visibility -->
+                  <div class="form-row">
+                    <div class="form-group">
+                      <label class="form-label">Folder</label>
+                      <select v-model="form.folder_id" class="base-input">
+                        <option :value="null">No folder (Unfiled)</option>
+                        <option v-for="f in folders" :key="f.id" :value="f.id">
+                          {{ f.visibility === 'shared' ? '🌐' : '🔒' }} {{ f.name }}
+                        </option>
+                      </select>
+                    </div>
+                    <div class="form-group">
+                      <label class="form-label">Visibility</label>
+                      <div style="display:flex;gap:8px;height:100%;align-items:flex-end">
+                        <label class="vis-radio" :class="{ active: form.visibility === 'shared' }">
+                          <input type="radio" v-model="form.visibility" value="shared" style="display:none" />
+                          🌐 Shared
+                        </label>
+                        <label class="vis-radio" :class="{ active: form.visibility === 'private' }">
+                          <input type="radio" v-model="form.visibility" value="private" style="display:none" />
+                          🔒 Private
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </details>
+
+              <!-- Test result -->
+              <div v-if="testResult" class="notice" :class="testResult.ok ? 'notice--success' : 'notice--error'">
+                <svg v-if="testResult.ok" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                <svg v-else width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+                {{ testResult.message }}
+              </div>
+
+            </div>
+
+            <!-- Footer -->
+            <div class="conn-modal-foot">
+              <button class="base-btn base-btn--ghost base-btn--sm" :disabled="testing" @click="handleTest">
+                <svg v-if="testing" class="spin" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+                {{ testing ? 'Testing…' : 'Test Connection' }}
+              </button>
+              <div style="display:flex;gap:8px">
+                <button class="base-btn base-btn--ghost base-btn--sm" @click="showForm = false; resetForm()">Cancel</button>
+                <button class="base-btn base-btn--primary base-btn--sm" :disabled="saving" @click="handleSave">
+                  <svg v-if="saving" class="spin" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+                  {{ saving ? (editingId ? 'Updating…' : 'Saving…') : (editingId ? 'Update Connection' : 'Save Connection') }}
+                </button>
+              </div>
+            </div>
+
           </div>
         </div>
       </Transition>
-        </div>
-      </div>
-    </div>
+    </Teleport>
+
   </div>
 </template>
 
@@ -587,106 +880,172 @@ async function handleReconnect(id: number, name: string) {
   background: var(--bg-body);
 }
 
-.conn-layout {
-  display: flex;
-  gap: 20px;
-  align-items: flex-start;
+/* ── Connection panel ── */
+.conn-panel {
+  padding: 20px;
 }
 
-.conn-list {
-  flex: 1;
-  min-width: 0;
-  padding: 18px;
-}
-
-.conn-list__head {
+.conn-panel__head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 14px;
+  margin-bottom: 16px;
 }
 
-.conn-list__title {
+.conn-panel__title {
   font-size: 15px;
   font-weight: 700;
   color: var(--text-primary);
 }
 
-.conn-list__sub {
-  margin-top: 4px;
+.conn-panel__sub {
+  margin-top: 2px;
   font-size: 12px;
   color: var(--text-muted);
 }
 
-.conn-list {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.conn-row {
+.conn-loading {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px 14px;
-  background: var(--bg-surface);
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 13px;
+  padding: 24px;
+}
+
+/* ── Empty state ── */
+.conn-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 56px 24px;
+  text-align: center;
+}
+
+.conn-empty__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  background: var(--bg-body);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
+.conn-empty__title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.conn-empty__sub {
+  font-size: 13px;
+  color: var(--text-muted);
+  max-width: 380px;
+  line-height: 1.6;
+}
+
+/* ── Connection cards ── */
+.conn-items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.conn-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  background: var(--bg-body);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  border-left: 3px solid var(--border);
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
-.conn-row:hover {
+.conn-card:hover {
   border-color: var(--brand);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand) 20%, transparent);
+  border-left-color: var(--brand);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--brand) 15%, transparent);
 }
 
-.conn-row__badge {
+.conn-card--disconnected {
+  opacity: 0.65;
+}
+
+/* Category-specific left border colors */
+.conn-card--rdbms        { border-left-color: #336791; }
+.conn-card--rdbms:hover  { border-left-color: #336791; }
+.conn-card--cache        { border-left-color: #c6302b; }
+.conn-card--cache:hover  { border-left-color: #c6302b; }
+.conn-card--streaming    { border-left-color: #231f20; }
+.conn-card--streaming:hover { border-left-color: #231f20; }
+.conn-card--s3           { border-left-color: #f59e0b; }
+.conn-card--s3:hover     { border-left-color: #f59e0b; }
+
+.conn-card__badge {
   width: 40px;
   height: 40px;
-  border-radius: 9px;
-  font-size: 12px;
+  border-radius: 10px;
+  font-size: 11px;
   font-weight: 700;
   flex-shrink: 0;
 }
 
-.conn-row__body {
+.conn-card__body {
   flex: 1;
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 3px;
 }
 
-.conn-row__top {
+.conn-card__title-row {
   display: flex;
   align-items: center;
   gap: 7px;
   flex-wrap: wrap;
 }
 
-.conn-row__name {
+.conn-card__name {
   font-size: 13px;
   font-weight: 600;
   color: var(--text-primary);
 }
 
-.conn-row__driver {
+.conn-card__driver-tag {
   font-size: 10.5px;
   font-weight: 500;
   color: var(--text-muted);
-  background: var(--bg-body);
+  background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: 4px;
   padding: 1px 6px;
 }
 
-.conn-row__vis {
-  font-size: 11px;
-  opacity: 0.7;
+.conn-card__category-tag {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--brand);
+  background: var(--brand-dim);
+  border-radius: 4px;
+  padding: 1px 6px;
+  letter-spacing: 0.02em;
 }
 
-.conn-row__host {
+.conn-card__vis {
   font-size: 11px;
+  opacity: 0.6;
+}
+
+.conn-card__detail {
+  font-size: 11.5px;
   font-family: var(--mono);
   color: var(--text-muted);
   white-space: nowrap;
@@ -694,26 +1053,104 @@ async function handleReconnect(id: number, name: string) {
   text-overflow: ellipsis;
 }
 
-.conn-row__folder {
-  font-size: 10.5px;
-  color: var(--text-muted);
+.conn-card__meta-row {
   display: flex;
   align-items: center;
-  gap: 3px;
-}
-.conn-row__folder::before {
-  content: '📁';
-  font-size: 10px;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 1px;
 }
 
-.conn-row__actions {
+.conn-card__folder {
   display: flex;
   align-items: center;
   gap: 4px;
+  font-size: 10.5px;
+  color: var(--text-muted);
+}
+
+.conn-card__tags {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.conn-card__ssl-badge,
+.conn-card__ssh-badge {
+  font-size: 9.5px;
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 3px;
+  letter-spacing: 0.04em;
+}
+
+.conn-card__ssl-badge {
+  background: color-mix(in srgb, var(--success) 14%, transparent);
+  color: var(--success);
+}
+
+.conn-card__ssh-badge {
+  background: color-mix(in srgb, var(--warning) 14%, transparent);
+  color: var(--warning);
+}
+
+/* Status + actions column */
+.conn-card__right {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
   flex-shrink: 0;
 }
 
-.conn-row__folder-sel {
+.conn-card__status {
+  display: flex;
+  align-items: center;
+}
+
+.conn-status {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 99px;
+}
+
+.conn-status::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.conn-status--on {
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 12%, transparent);
+}
+
+.conn-status--on::before {
+  background: var(--success);
+}
+
+.conn-status--off {
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+}
+
+.conn-status--off::before {
+  background: var(--danger);
+}
+
+.conn-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.conn-card__folder-sel {
   height: 28px;
   padding: 0 6px;
   font-size: 11.5px;
@@ -722,73 +1159,264 @@ async function handleReconnect(id: number, name: string) {
   border-radius: 6px;
   color: var(--text-secondary);
   cursor: pointer;
-  max-width: 130px;
+  max-width: 120px;
 }
 
-.conn-form {
-  width: 380px;
-  flex-shrink: 0;
+/* ── Connection badge colors ── */
+.conn-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+}
+
+.conn-badge--postgres  { background: #336791; }
+.conn-badge--mysql     { background: #e48e00; }
+.conn-badge--mariadb   { background: #c0765a; }
+.conn-badge--mssql     { background: #cc2927; }
+.conn-badge--redis     { background: #c6302b; }
+.conn-badge--memcache  { background: #16a34a; }
+.conn-badge--kafka     { background: #231f20; }
+.conn-badge--sqlite    { background: #4b5563; }
+.conn-badge--s3_aws    { background: #f59e0b; }
+.conn-badge--s3_gcp    { background: #4285f4; }
+.conn-badge--s3_oss    { background: #ff6a00; }
+.conn-badge--s3_obs    { background: #c00000; }
+
+/* ── Modal backdrop + shell ── */
+.conn-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 500;
+  padding: 24px;
+}
+
+.conn-modal-shell {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-2);
+  border-radius: 18px;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+  width: 100%;
+  max-width: 560px;
+  max-height: calc(100dvh - 48px);
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
 }
 
-@media (max-width: 1040px) {
-  .conn-layout {
-    flex-direction: column;
-  }
-
-  .conn-form {
-    width: 100%;
-  }
+.conn-modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
 }
 
-/* ── Provider cards ── */
-.provider-groups {
+.conn-modal-head__left {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.conn-modal-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.conn-modal-subtitle {
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+
+.conn-modal-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.conn-modal-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+/* ── Modal transitions ── */
+.conn-modal-enter-active,
+.conn-modal-leave-active {
+  transition: opacity 0.18s var(--ease);
+}
+
+.conn-modal-enter-active .conn-modal-shell,
+.conn-modal-leave-active .conn-modal-shell {
+  transition: transform 0.18s var(--ease), opacity 0.18s var(--ease);
+}
+
+.conn-modal-enter-from,
+.conn-modal-leave-to {
+  opacity: 0;
+}
+
+.conn-modal-enter-from .conn-modal-shell,
+.conn-modal-leave-to .conn-modal-shell {
+  transform: scale(0.96) translateY(8px);
+  opacity: 0;
+}
+
+/* ── URL import ── */
+.url-import-btn {
+  width: 100%;
+  justify-content: center;
+}
+
+.url-import-row {
+  margin-top: 8px;
+  display: flex;
+  gap: 6px;
+}
+
+/* ── Form sections ── */
+.form-section {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
+.form-section__label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.form-section__num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--brand);
+  color: var(--brand-fg);
+  font-size: 10px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+/* ── Driver description hint ── */
+.driver-hint {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--brand-dim);
+  border: 1px solid color-mix(in srgb, var(--brand) 20%, transparent);
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--brand);
+  line-height: 1.5;
+}
+
+.driver-hint svg {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+/* ── Field helpers ── */
+.field-optional {
+  font-size: 10.5px;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin-left: 4px;
+}
+
+.field-check-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.field-check-label {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.field-note {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  padding: 8px 10px;
+  background: var(--bg-body);
+  border-radius: 7px;
+  line-height: 1.4;
+}
+
+.field-note--info {
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 8%, transparent);
+}
+
+/* ── Provider picker ── */
+.provider-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 .provider-group {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 5px;
 }
 
 .provider-group__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  color: var(--text-muted);
-  font-size: 10.5px;
+  font-size: 10px;
   font-weight: 700;
-  letter-spacing: 0;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-}
-
-.provider-group__empty {
-  padding: 8px 10px;
-  border: 1px dashed var(--border);
-  border-radius: var(--r-sm);
   color: var(--text-muted);
-  font-size: 11px;
 }
 
 .provider-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 6px;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 5px;
 }
 
 .provider-card {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: 7px;
+  padding: 8px 10px;
   border: 1.5px solid var(--border);
-  border-radius: var(--r-md);
-  background: var(--bg-surface);
+  border-radius: 9px;
+  background: var(--bg-body);
   cursor: pointer;
-  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+  transition: border-color 0.13s, background 0.13s, box-shadow 0.13s;
   position: relative;
   text-align: left;
   width: 100%;
@@ -796,21 +1424,26 @@ async function handleReconnect(id: number, name: string) {
 
 .provider-card:hover {
   border-color: var(--brand);
-  background: color-mix(in srgb, var(--brand) 6%, var(--bg-surface));
+  background: color-mix(in srgb, var(--brand) 6%, var(--bg-elevated));
+}
+
+.provider-card.is-active {
+  border-color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 10%, var(--bg-elevated));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand) 15%, transparent);
 }
 
 .provider-card__icon {
-  width: 30px;
-  height: 30px;
+  width: 26px;
+  height: 26px;
   border-radius: 6px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 10px;
+  font-size: 9px;
   font-weight: 700;
   flex-shrink: 0;
   color: #fff;
-  background: var(--text-muted);
 }
 
 .provider-card__icon--postgres { background: #336791; }
@@ -818,7 +1451,13 @@ async function handleReconnect(id: number, name: string) {
 .provider-card__icon--mariadb  { background: #c0765a; }
 .provider-card__icon--mssql    { background: #cc2927; }
 .provider-card__icon--redis    { background: #c6302b; }
+.provider-card__icon--memcache { background: #16a34a; }
 .provider-card__icon--kafka    { background: #231f20; }
+.provider-card__icon--sqlite   { background: #4b5563; }
+.provider-card__icon--s3_aws   { background: #f59e0b; }
+.provider-card__icon--s3_gcp   { background: #4285f4; }
+.provider-card__icon--s3_oss   { background: #ff6a00; }
+.provider-card__icon--s3_obs   { background: #c00000; }
 
 .provider-card__body {
   display: flex;
@@ -829,14 +1468,21 @@ async function handleReconnect(id: number, name: string) {
 }
 
 .provider-card__name {
-  font-size: 12px;
+  font-size: 11.5px;
   font-weight: 600;
   color: var(--text-primary);
   line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.provider-card.is-active .provider-card__name {
+  color: var(--brand);
 }
 
 .provider-card__sub {
-  font-size: 10.5px;
+  font-size: 10px;
   color: var(--text-muted);
 }
 
@@ -845,13 +1491,110 @@ async function handleReconnect(id: number, name: string) {
   flex-shrink: 0;
 }
 
-.provider-card.is-active {
-  border-color: var(--brand);
-  background: color-mix(in srgb, var(--brand) 8%, var(--bg-surface));
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand) 15%, transparent);
+/* ── Advanced section ── */
+.conn-advanced {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
 }
 
-.provider-card.is-active .provider-card__name {
+.conn-advanced__trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 14px;
+  cursor: pointer;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  list-style: none;
+  user-select: none;
+  background: var(--bg-body);
+  transition: background 0.12s;
+}
+
+.conn-advanced__trigger:hover {
+  background: var(--bg-elevated);
+}
+
+.conn-advanced__hint {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin-left: 2px;
+}
+
+.conn-advanced__body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  border-top: 1px solid var(--border);
+}
+
+.adv-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.adv-section__label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+/* ── Conn tag ── */
+.conn-tag {
+  font-size: 9px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--brand-dim);
   color: var(--brand);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+/* ── Responsive ── */
+@media (max-width: 680px) {
+  .conn-card {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .conn-card__right {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .conn-modal-backdrop {
+    padding: 12px;
+    align-items: flex-end;
+  }
+
+  .conn-modal-shell {
+    max-width: 100%;
+    max-height: calc(100dvh - 24px);
+    border-radius: 16px 16px 0 0;
+  }
+
+  .provider-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .conn-card__title-row {
+    gap: 5px;
+  }
+
+  .conn-card__category-tag {
+    display: none;
+  }
 }
 </style>

--- a/web/src/views/DataView.vue
+++ b/web/src/views/DataView.vue
@@ -115,7 +115,11 @@ const pickerStyle = computed(() => ({
 }))
 
 // Cache and streaming connections have no SQL DSN — exclude them from SQL Studio.
-const sqlConns = computed(() => connections.value.filter(c => c.driver !== 'redis' && c.driver !== 'memcache' && c.driver !== 'kafka'))
+function isNonSqlDriver(driver: string) {
+  return driver === 'redis' || driver === 'memcache' || driver === 'kafka' || driver === 's3_aws' || driver === 's3_gcp' || driver === 's3_oss' || driver === 's3_obs'
+}
+
+const sqlConns = computed(() => connections.value.filter(c => !isNonSqlDriver(c.driver)))
 
 const filteredConns = computed(() =>
   pickerSearch.value
@@ -167,7 +171,7 @@ onBeforeUnmount(() => document.removeEventListener('mousedown', onDocClick, true
 watch(() => props.activeConnId, (id) => {
   if (id == null) return
   const conn = connections.value.find(c => c.id === id)
-  if (conn?.driver === 'redis' || conn?.driver === 'memcache') return
+  if (conn && isNonSqlDriver(conn.driver)) return
   const existing = sessions.value.find(s => s.connId === id)
   if (existing) {
     // Session already open — just bring it to focus
@@ -199,7 +203,7 @@ function onPickerKeydown(e: KeyboardEvent) { if (e.key === 'Escape') pickerOpen.
 const activeConnIsRedis = computed(() => {
   if (props.activeConnId == null) return false
   const driver = connections.value.find(c => c.id === props.activeConnId)?.driver
-  return driver === 'redis' || driver === 'memcache'
+  return !!driver && isNonSqlDriver(driver)
 })
 
 // Show landing page when there are no sessions OR active conn is Redis

--- a/web/src/views/DatabaseObjectsView.vue
+++ b/web/src/views/DatabaseObjectsView.vue
@@ -39,6 +39,10 @@ const activeConn = computed(() =>
   connId.value != null ? connections.value.find(c => c.id === connId.value) ?? null : null
 )
 
+function isNonSqlDriver(driver: string) {
+  return driver === 'redis' || driver === 'memcache' || driver === 'kafka' || driver === 's3_aws' || driver === 's3_gcp' || driver === 's3_oss' || driver === 's3_obs'
+}
+
 const availableTabs = computed(() => {
   if (!metadata.value) return []
   return tabDefs.filter(t => {
@@ -75,7 +79,7 @@ const filteredItems = computed(() => {
 watch(() => props.activeConnId, async (id) => {
   if (id == null) return
   const conn = connections.value.find(c => c.id === id)
-  if (!conn || conn.driver === 'redis' || conn.driver === 'memcache' || conn.driver === 'kafka') return
+  if (!conn || isNonSqlDriver(conn.driver)) return
   if (connId.value === id) return
   connId.value = id
 }, { immediate: true })
@@ -170,7 +174,7 @@ function countForTab(key: string): number {
             >
               <option :value="null">— select —</option>
               <option
-                v-for="c in connections.filter(c => c.driver !== 'redis' && c.driver !== 'memcache' && c.driver !== 'kafka')"
+                v-for="c in connections.filter(c => !isNonSqlDriver(c.driver))"
                 :key="c.id"
                 :value="c.id"
               >{{ c.name }}</option>

--- a/web/src/views/LaravelQueueView.vue
+++ b/web/src/views/LaravelQueueView.vue
@@ -123,12 +123,16 @@ interface MainDataResult {
 
 const redisDbIndexes = Array.from({ length: 16 }, (_, index) => index)
 const redisConnections = computed(() => connections.value.filter((c) => c.driver === 'redis'))
-const sqlConnections = computed(() => connections.value.filter((c) => c.driver !== 'redis' && c.driver !== 'memcache' && c.driver !== 'kafka'))
+function isNonSqlDriver(driver: string) {
+  return driver === 'redis' || driver === 'memcache' || driver === 'kafka' || driver === 's3_aws' || driver === 's3_gcp' || driver === 's3_oss' || driver === 's3_obs'
+}
+
+const sqlConnections = computed(() => connections.value.filter((c) => !isNonSqlDriver(c.driver)))
 const activeConn = computed(() =>
   props.activeConnId != null ? connections.value.find((c) => c.id === props.activeConnId) ?? null : null,
 )
 const isRedis = computed(() => activeConn.value?.driver === 'redis')
-const isSql = computed(() => activeConn.value != null && activeConn.value.driver !== 'redis' && activeConn.value.driver !== 'memcache' && activeConn.value.driver !== 'kafka')
+const isSql = computed(() => activeConn.value != null && !isNonSqlDriver(activeConn.value.driver))
 // When in SQL-only mode, the user picks a Redis conn just for the retry-push step
 const retryRedisConnId = ref<number | null>(null)
 const filteredJobs = computed(() => {

--- a/web/src/views/SchemaView.vue
+++ b/web/src/views/SchemaView.vue
@@ -22,7 +22,11 @@ const detailLoading = ref(false)
 const activeConn = computed(() =>
   localConnId.value ? connections.value.find(c => c.id === localConnId.value) ?? null : null
 )
-const supportsRelationalSchema = computed(() => !!activeConn.value && activeConn.value.driver !== 'redis' && activeConn.value.driver !== 'memcache' && activeConn.value.driver !== 'kafka')
+function isNonSqlDriver(driver: string) {
+  return driver === 'redis' || driver === 'memcache' || driver === 'kafka' || driver === 's3_aws' || driver === 's3_gcp' || driver === 's3_oss' || driver === 's3_obs'
+}
+
+const supportsRelationalSchema = computed(() => !!activeConn.value && !isNonSqlDriver(activeConn.value.driver))
 
 watch(() => props.activeConnId, (id) => {
   if (id != null) localConnId.value = id


### PR DESCRIPTION
## Summary

  Adds backup-to-object-storage support. The change introduces S3-compatible bucket connections for AWS S3, GCP Storage, Alibaba OSS, and Huawei OBS,
  including connection validation, signed bucket list/upload requests, and new backup endpoints:

  - POST /api/backup/to-bucket
  - GET /api/backup/bucket-list

  It also expands backup options, updates the Backup UI with a bucket workflow and history list, refreshes the Connections UI, and adds shared driver
  icons.

  ## Verification

  - [x] cd server && go test ./...
  - [x] cd web && npm run build
  - [x] Manual UI verification, if applicable

  ## Checklist

  - [x] The change is focused and reviewable.
  - [x] Documentation was updated when behavior or configuration changed. No docs changes detected.
  - [x] No secrets, local databases, logs, or generated build output are committed.
  - [x] Security and permission impact was considered.