### PR TITLE
fix: fix save button in the sql panel

### DIFF
--- a/server/handlers/history.go
+++ b/server/handlers/history.go
@@ -25,11 +25,11 @@ func GetHistory() http.HandlerFunc {
 		parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/connections/"), "/")
 		connID, _ := strconv.ParseInt(parts[0], 10, 64)
 
-		rows, err := appdb.DB.Query(`
+		rows, err := appdb.DB.Query(appdb.ConvertQuery(`
 			SELECT id, conn_id, sql, duration_ms, row_count, error, executed_at
 			FROM query_history WHERE conn_id = ?
 			ORDER BY executed_at DESC LIMIT 200
-		`, connID)
+		`), connID)
 		if err != nil {
 			http.Error(w, jsonError(err.Error()), http.StatusInternalServerError)
 			return
@@ -67,7 +67,7 @@ func SaveHistory() http.HandlerFunc {
 		}
 
 		res, err := appdb.DB.Exec(
-			`INSERT INTO query_history (conn_id, sql, duration_ms, row_count, error) VALUES (?, ?, ?, ?, ?)`,
+			appdb.ConvertQuery(`INSERT INTO query_history (conn_id, sql, duration_ms, row_count, error) VALUES (?, ?, ?, ?, ?)`),
 			connID, body.SQL, body.DurationMs, body.RowCount, body.Error,
 		)
 		if err != nil {

--- a/web/src/components/database/DataSessionPane.vue
+++ b/web/src/components/database/DataSessionPane.vue
@@ -361,13 +361,14 @@ async function exportExcel() { if (!rows.value.length) return; const { downloadE
 // ── Sub-tab + SQL tabs ────────────────────────────────────────────
 type ResultKind = 'query' | 'explain' | 'stream' | 'script' | 'history' | 'saved' | 'error' | 'chart'
 interface PinnedResult { id: string; label: string; columns: string[]; rows: unknown[][] }
-interface SQLViewTab { id: string; label: string; result: SQLPanelPayload | null; activeResultTab: ResultKind; sqlHeight: number; pinnedResults: PinnedResult[]; diffLeft: string; diffRight: string; initialSQL?: string; sqlEditMode?: boolean; sqlEditPkColumn?: string; sqlEditTarget?: SQLEditTarget }
+interface SQLViewTab { id: string; label: string; result: SQLPanelPayload | null; activeResultTab: ResultKind; sqlHeight: number; pinnedResults: PinnedResult[]; diffLeft: string; diffRight: string; initialSQL?: string; sqlEditMode?: boolean; sqlEditPkColumn?: string; sqlEditTarget?: SQLEditTarget; sqlDirtyCount?: number }
 interface SQLEditTarget { db: string; table: string }
 interface PersistedSQLTab { label: string; result: SQLPanelPayload | null; activeResultTab: ResultKind; sqlHeight: number; pinnedResults: PinnedResult[]; diffLeft: string; diffRight: string; sql: string }
 interface PersistedSQLState { tabs: PersistedSQLTab[]; activeIndex: number }
 
 const sqlViewTabs = ref<SQLViewTab[]>([])
 const sqlPanelRefs = ref<Record<string, InstanceType<typeof SQLPanel>>>({})
+const sqlVTableRefs = ref<Record<string, InstanceType<typeof VirtualTable>>>({})
 let sqlTabCounter = 0
 let restoringSQLState = false
 
@@ -562,7 +563,12 @@ function editableTargetForSQLResult(tab: SQLViewTab): SQLEditTarget | null {
   if (!parts.length) return null
   const table = parts[parts.length - 1]
   const explicitDb = parts.length >= 2 ? parts[parts.length - 2] : ''
-  const db = explicitDb || (tab.result as any).database || selected.value?.db || activeConn.value?.database || 'public'
+  // For PostgreSQL the namespace is the *schema* (e.g. "public"), NOT the connection's
+  // database name. Only fall back to the database name for MySQL/MariaDB/MSSQL where
+  // the namespace IS the database name.
+  const isPostgres = activeConn.value?.driver === 'postgres'
+  const dbFallback = isPostgres ? 'public' : (activeConn.value?.database ?? 'public')
+  const db = explicitDb || (tab.result as any).schema || selected.value?.db || dbFallback
   return { db, table }
 }
 
@@ -597,14 +603,29 @@ async function handleSQLResultSaveRow(
 ) {
   const target = tab.sqlEditTarget
   if (!target || !props.connId) return
+  if (!tab.sqlEditPkColumn) {
+    toast.error('Cannot save: no primary key column detected for this table')
+    return
+  }
   try {
+    const body = { pk_column: tab.sqlEditPkColumn, pk_value: payload.pkValue, updates: payload.changes }
+    console.log('[EditRow] PUT', target, body)
     await axios.put(
       `/api/connections/${props.connId}/schema/${target.db}/tables/${target.table}/rows`,
-      { pk_column: tab.sqlEditPkColumn, pk_value: payload.pkValue, updates: payload.changes },
+      body,
     )
     toast.success('Row updated')
   } catch (e: any) {
-    toast.error(e.response?.data?.error ?? 'Update failed')
+    // Backend returns text/plain with a JSON body — parse accordingly
+    const raw = e.response?.data
+    let msg = e.message ?? 'Update failed'
+    if (typeof raw === 'string') {
+      try { msg = JSON.parse(raw)?.error ?? raw } catch { msg = raw }
+    } else if (raw?.error) {
+      msg = raw.error
+    }
+    console.error('[EditRow] save failed:', msg, e.response)
+    toast.error(`Save failed: ${msg}`)
   }
 }
 
@@ -1080,7 +1101,7 @@ function driverLabel(d: string) { return ({ postgres: 'PG', mysql: 'MY', mariadb
                 :class="tab.sqlEditMode ? 'base-btn--primary' : 'base-btn--ghost'"
                 :disabled="!editableTargetForSQLResult(tab)"
                 @click="editSQLResultRows(tab)"
-                :title="tab.sqlEditMode ? 'Exit edit mode' : 'Edit rows inline (double-click a cell to edit)'"
+                :title="tab.sqlEditMode ? 'Exit edit mode' : 'Edit rows inline — double-click a cell to edit'"
               >
                 {{ tab.sqlEditMode ? 'Editing…' : 'Edit Rows' }}
               </button>
@@ -1098,12 +1119,14 @@ function driverLabel(d: string) { return ({ postgres: 'PG', mysql: 'MY', mariadb
             </div>
             <template v-else-if="(tab.result.kind==='query'||tab.result.kind==='stream')&&tab.activeResultTab!=='chart'">
               <VirtualTable
+                :ref="(el: any) => { if (el) sqlVTableRefs[tab.id] = el; else delete sqlVTableRefs[tab.id] }"
                 :columns="(tab.result as any).columns"
                 :rows="(tab.result as any).rows"
                 :selectable="true"
                 :editable="tab.sqlEditMode ?? false"
                 :pk-column="tab.sqlEditPkColumn ?? ''"
                 @save-row="handleSQLResultSaveRow(tab, $event)"
+                @dirty-change="(n: number) => tab.sqlDirtyCount = n"
               />
             </template>
             <template v-else-if="tab.result.kind==='query'&&tab.activeResultTab==='chart'">

--- a/web/src/components/database/VirtualTable.vue
+++ b/web/src/components/database/VirtualTable.vue
@@ -30,7 +30,7 @@ const emit = defineEmits<{
   (e: 'bulk-export', rows: unknown[][], format: 'csv' | 'json'): void
   (e: 'profile-column', column: string): void
   (e: 'save-row', payload: { rowIdx: number; pkValue: unknown; changes: Record<string, unknown> }): void
-  (e: 'dirty-change', hasDirty: boolean): void
+  (e: 'dirty-change', dirtyCount: number): void
 }>()
 
 // ── Inline editing ────────────────────────────────────────────────────────────
@@ -61,14 +61,14 @@ function commitEdit() {
   dirtyRows.value.get(origIdx)![col] = value
   dirtyRows.value = new Map(dirtyRows.value) // trigger reactivity
   editingCell.value = null
-  emit('dirty-change', dirtyRows.value.size > 0)
+  emit('dirty-change', dirtyRows.value.size)
 }
 
 function discardRow(displayIdx: number) {
   const origIdx = realRowIdx(displayIdx)
   dirtyRows.value.delete(origIdx)
   dirtyRows.value = new Map(dirtyRows.value)
-  emit('dirty-change', dirtyRows.value.size > 0)
+  emit('dirty-change', dirtyRows.value.size)
 }
 
 function saveRow(displayIdx: number) {
@@ -80,11 +80,13 @@ function saveRow(displayIdx: number) {
   emit('save-row', { rowIdx: origIdx, pkValue, changes })
   dirtyRows.value.delete(origIdx)
   dirtyRows.value = new Map(dirtyRows.value)
-  emit('dirty-change', dirtyRows.value.size > 0)
+  emit('dirty-change', dirtyRows.value.size)
 }
 
 function saveAllRows() {
-  for (const [origIdx] of dirtyRows.value) {
+  // snapshot keys before iterating since saveRow mutates the map
+  const keys = [...dirtyRows.value.keys()]
+  for (const origIdx of keys) {
     const displayIdx = sortCol.value
       ? displayRows.value.findIndex(r => props.rows.indexOf(r) === origIdx)
       : origIdx
@@ -94,8 +96,10 @@ function saveAllRows() {
 
 function discardAllRows() {
   dirtyRows.value = new Map()
-  emit('dirty-change', false)
+  emit('dirty-change', 0)
 }
+
+defineExpose({ saveAllRows, discardAllRows })
 
 // Display value: prefer dirty edit over original
 function displayVal(displayIdx: number, colIdx: number, origVal: unknown): unknown {
@@ -332,14 +336,24 @@ function autoFitCol(col: string) {
     <!-- Table -->
     <template v-else>
       <!-- Edit-mode banner -->
-      <div v-if="editable" class="vt-edit-banner">
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
-        Edit mode — double-click any cell to edit
-        <template v-if="dirtyRows.size > 0">
-          · <strong>{{ dirtyRows.size }} unsaved row{{ dirtyRows.size > 1 ? 's' : '' }}</strong>
-          <button class="vt-edit-save-all" @click="saveAllRows">Save all</button>
-          <button class="vt-edit-discard-all" @click="discardAllRows">Discard all</button>
-        </template>
+      <div v-if="editable" class="vt-edit-banner" :class="{ 'vt-edit-banner--dirty': dirtyRows.size > 0 }">
+        <!-- Left: hint -->
+        <div class="vt-edit-banner__info">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+          <span><strong>Edit mode</strong> — double-click a cell to edit, Enter to confirm, Esc to cancel</span>
+        </div>
+        <!-- Right: save actions -->
+        <div class="vt-edit-banner__actions">
+          <template v-if="dirtyRows.size > 0">
+            <span class="vt-edit-unsaved">{{ dirtyRows.size }} unsaved</span>
+            <button class="vt-btn-discard" @click="discardAllRows">Discard</button>
+            <button class="vt-btn-save" @click="saveAllRows">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+              Save {{ dirtyRows.size }} row{{ dirtyRows.size > 1 ? 's' : '' }}
+            </button>
+          </template>
+          <span v-else style="font-size:11.5px;color:var(--text-secondary);opacity:.7">No changes yet</span>
+        </div>
       </div>
 
       <!-- Bulk action toolbar -->
@@ -443,14 +457,13 @@ function autoFitCol(col: string) {
                 />
                 <template v-else>{{ formatCell(displayVal(displayStart + i, cIdx, val)) }}</template>
               </div>
-              <!-- Row save/discard actions (shown when row is dirty) -->
+              <!-- Per-row discard (small, inline) -->
               <div
                 v-if="editable && dirtyRows.has(realRowIdx(displayStart + i))"
                 class="vt-cell vt-row-actions"
                 @click.stop
               >
-                <button class="vt-row-save" @click="saveRow(displayStart + i)">Save</button>
-                <button class="vt-row-discard" @click="discardRow(displayStart + i)">✕</button>
+                <button class="vt-row-discard" title="Discard this row's changes" @click="discardRow(displayStart + i)">✕</button>
               </div>
             </div>
           </div>
@@ -615,24 +628,51 @@ function autoFitCol(col: string) {
 .vt-bool { color: #c084fc; }
 .vt-sort-icon { font-size: 10px; margin-left: 4px; opacity: 0.6; }
 
-/* Edit mode */
+/* Edit mode banner */
 .vt-edit-banner {
-  display: flex; align-items: center; gap: 8px; flex-shrink: 0;
-  padding: 5px 12px; font-size: 12px; font-weight: 500;
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px; flex-shrink: 0;
+  padding: 7px 14px;
+  font-size: 12px;
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
   color: var(--accent);
 }
-.vt-edit-save-all {
-  padding: 2px 10px; font-size: 11.5px; font-weight: 600;
-  background: var(--accent); color: #fff; border: none;
-  border-radius: 5px; cursor: pointer;
+.vt-edit-banner--dirty {
+  background: color-mix(in srgb, #f59e0b 8%, transparent);
+  border-bottom-color: color-mix(in srgb, #f59e0b 30%, transparent);
+  color: #b45309;
 }
-.vt-edit-discard-all {
-  padding: 2px 10px; font-size: 11.5px; font-weight: 600;
+.vt-edit-banner__info {
+  display: flex; align-items: center; gap: 7px;
+  font-size: 12px; flex: 1; min-width: 0;
+  overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+}
+.vt-edit-banner__actions {
+  display: flex; align-items: center; gap: 8px; flex-shrink: 0;
+}
+.vt-edit-unsaved {
+  font-size: 11.5px; font-weight: 600; color: #d97706;
+  background: rgba(245,158,11,.12); padding: 2px 8px;
+  border-radius: 4px; white-space: nowrap;
+}
+.vt-btn-save {
+  display: flex; align-items: center; gap: 5px;
+  padding: 5px 14px; font-size: 12.5px; font-weight: 700;
+  background: #22c55e; color: #fff; border: none;
+  border-radius: 6px; cursor: pointer; white-space: nowrap;
+  box-shadow: 0 1px 4px rgba(34,197,94,.35);
+  transition: opacity .15s;
+}
+.vt-btn-save:hover { opacity: .88; }
+.vt-btn-discard {
+  padding: 5px 12px; font-size: 12px; font-weight: 500;
   background: none; color: var(--text-secondary);
-  border: 1px solid var(--border); border-radius: 5px; cursor: pointer;
+  border: 1px solid var(--border); border-radius: 6px;
+  cursor: pointer; white-space: nowrap;
+  transition: background .1s;
 }
+.vt-btn-discard:hover { background: var(--border); }
 .vt-row--dirty { background: color-mix(in srgb, #f59e0b 6%, transparent) !important; }
 .vt-row--dirty:hover { background: color-mix(in srgb, #f59e0b 10%, transparent) !important; }
 .vt-cell--edited {


### PR DESCRIPTION
## Summary

Adds Search Policy Management as a dedicated feature for Elasticsearch and OpenSearch connections. Users can now view and manage ILM lifecycle policies, index templates, app-level monitoring rules, and per-index shard/allocation settings — all from a single view. Also adds a per-index delete action in the Search Browser with confirmation, and fixes a PostgreSQL type error when reading nullable timestamp columns.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement to existing feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Chore / dependency update

## What Changed

- **Search Browser** — added a delete button on each index row (hover to reveal, confirmation modal before deleting)
- **Search Policies view** — new route `/search-policies` with 4 tabs:
  - **ILM Policies** — list, create, edit, and delete built-in ES/OS lifecycle policies
  - **Index Templates** — list, create, edit, and delete index templates with full JSON editor
  - **App Policies** — NIAS-managed rules (size alert, auto-delete by size or age) stored in the internal DB; includes a Run button that evaluates violations across all indices and shows results inline
  - **Shard Rules** — browse per-index shard/replica/allocation settings and update dynamic settings
- **Backend** — new `search_management.go` (ILM, template, index settings proxies) and `search_app_policies.go` (CRUD + evaluation engine); 12 new routes registered
- **DB migration** — new `search_app_policies` table (additive)
- **Navigation** — "Search Policies" added to the Database → Search & Observability section in TopNav with a dedicated icon
- **Bug fix** — `COALESCE(last_run_at, '')` on a `TIMESTAMP` column caused PostgreSQL error 22007; fixed by removing COALESCE and scanning with `sql.NullString`
- **PR template** — updated with Type of Change, What Changed, Related Issues sections and expanded checklist

## Related Issues

<!-- Link any related issues: Closes #123 -->

## Verification

- [ ] `cd server && go test ./...`
- [ ] `cd web && npm run build`
- [ ] Manual UI verification, if applicable
- [ ] Tested on PostgreSQL / MySQL (if DB changes are included)
- [ ] Tested on SQLite (default local setup)

## Checklist

- [ ] The change is focused and reviewable.
- [ ] New API endpoints are protected with appropriate permission checks.
- [ ] Database migrations are backward-compatible (additive only — no column drops or renames).
- [ ] Error messages are user-friendly and do not leak internal details.
- [ ] Documentation was updated when behavior or configuration changed.
- [ ] No secrets, local databases, logs, or generated build output are committed.
- [ ] Security and permission impact was considered.

## Screenshots

Add screenshots or video for visible UI changes.
