### PR TITLE
fix: fix hidden request download

### DIFF
--- a/server/handlers/backup_bucket.go
+++ b/server/handlers/backup_bucket.go
@@ -39,6 +39,10 @@ type BackupJob struct {
 	StartedAt time.Time       `json:"started_at"`
 	DoneAt    *time.Time      `json:"done_at,omitempty"`
 
+	// Live upload progress (updated atomically, no lock needed)
+	Stage         string `json:"stage"`           // "dumping" | "uploading"
+	UploadedBytes int64  `json:"uploaded_bytes"`  // bytes sent to bucket so far
+
 	// Result (populated on done)
 	ObjectKey         string `json:"object_key,omitempty"`
 	Bucket            string `json:"bucket,omitempty"`
@@ -48,8 +52,9 @@ type BackupJob struct {
 	// Error (populated on failed)
 	Error string `json:"error,omitempty"`
 
-	cancel context.CancelFunc
-	mu     sync.Mutex
+	cancel        context.CancelFunc
+	uploadCounter *int64 // points to countingReader.n for live reads
+	mu            sync.Mutex
 }
 
 var (
@@ -210,6 +215,7 @@ func BackupToBucket() http.HandlerFunc {
 		job := &BackupJob{
 			ID:        newJobID(),
 			Status:    BackupJobRunning,
+			Stage:     "dumping",
 			StartedAt: time.Now(),
 			cancel:    jobCancel,
 		}
@@ -240,6 +246,10 @@ func BackupToBucket() http.HandlerFunc {
 			}()
 
 			cr := &countingReader{r: pr}
+			job.mu.Lock()
+			job.Stage = "uploading"
+			job.uploadCounter = &cr.n
+			job.mu.Unlock()
 			uploadErr := uploadToBucketStream(jobCtx, dest, objectName, cr)
 			if uploadErr != nil {
 				pr.CloseWithError(uploadErr)
@@ -286,6 +296,9 @@ func GetBackupJobStatus() http.HandlerFunc {
 			return
 		}
 		job.mu.Lock()
+		if job.uploadCounter != nil {
+			job.UploadedBytes = atomic.LoadInt64(job.uploadCounter)
+		}
 		defer job.mu.Unlock()
 		json.NewEncoder(w).Encode(job)
 	}
@@ -414,8 +427,9 @@ func uploadToBucket(ctx interface {
 	return uploadToBucketStream(ctx, dest, objectKey, bytes.NewReader(data))
 }
 
-// DownloadFromBucket proxies a file from S3-compatible storage directly to the
-// browser, signing the request server-side so credentials are never exposed.
+// DownloadFromBucket generates a pre-signed URL and redirects the browser
+// directly to S3-compatible storage, bypassing the server for the data transfer.
+// For multi-GB files this is dramatically faster than proxying through the server.
 // GET /api/backup/bucket-download?dest_conn_id=N&object_key=path/to/file.sql.gz
 func DownloadFromBucket() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -437,50 +451,70 @@ func DownloadFromBucket() http.HandlerFunc {
 			return
 		}
 
-		endpointHost := buildS3Host(dest)
-		scheme := "https"
-		if !dest.SSL {
-			scheme = "http"
-		}
-		bucket := strings.Trim(dest.Bucket, "/")
-		virtualHost := bucket + "." + endpointHost
-		downloadURL := fmt.Sprintf("%s://%s/%s", scheme, virtualHost, url.PathEscape(objectKey))
-
-		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, downloadURL, nil)
+		signed, err := presignedDownloadURL(dest, objectKey, 60*time.Minute)
 		if err != nil {
-			http.Error(w, `{"error":"failed to build request: `+err.Error()+`"}`, http.StatusInternalServerError)
+			http.Error(w, `{"error":"failed to sign URL: `+err.Error()+`"}`, http.StatusInternalServerError)
 			return
 		}
 
-		payloadHash := sha256.Sum256([]byte{})
-		payloadHashHex := hex.EncodeToString(payloadHash[:])
-		region := objectStorageRegion(dest.Driver, endpointHost)
-		service := objectStorageService(dest.Driver)
-		signObjectStorageRequestFull(req, dest.Username, dest.Password, region, service, payloadHashHex, nil)
-
-		client := &http.Client{Timeout: 4 * time.Hour}
-		resp, err := client.Do(req)
-		if err != nil {
-			http.Error(w, `{"error":"download failed: `+err.Error()+`"}`, http.StatusBadGateway)
-			return
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode >= 400 {
-			http.Error(w, fmt.Sprintf(`{"error":"bucket returned HTTP %d"}`, resp.StatusCode), http.StatusBadGateway)
-			return
-		}
-
-		parts := strings.Split(objectKey, "/")
-		filename := parts[len(parts)-1]
-
-		w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
-		w.Header().Set("Content-Type", "application/octet-stream")
-		if cl := resp.Header.Get("Content-Length"); cl != "" {
-			w.Header().Set("Content-Length", cl)
-		}
-		io.Copy(w, resp.Body)
+		// Redirect browser directly to S3 — no proxying, full download speed.
+		http.Redirect(w, r, signed, http.StatusFound)
 	}
+}
+
+// presignedDownloadURL returns a time-limited pre-signed GET URL for an object.
+// The browser can use this URL to download directly from the bucket without
+// routing through the application server.
+func presignedDownloadURL(dest *bucketConnRow, objectKey string, expires time.Duration) (string, error) {
+	endpointHost := buildS3Host(dest)
+	scheme := "https"
+	if !dest.SSL {
+		scheme = "http"
+	}
+	bucket := strings.Trim(dest.Bucket, "/")
+	key := strings.TrimPrefix(objectKey, "/")
+	virtualHost := bucket + "." + endpointHost
+	objectURL := fmt.Sprintf("%s://%s/%s", scheme, virtualHost, url.PathEscape(key))
+
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+	region := objectStorageRegion(dest.Driver, endpointHost)
+	service := objectStorageService(dest.Driver)
+
+	expireSecs := int(expires.Seconds())
+	credScope := dateStamp + "/" + region + "/" + service + "/aws4_request"
+	credential := dest.Username + "/" + credScope
+
+	// Build canonical query string (params must be sorted alphabetically)
+	q := url.Values{}
+	q.Set("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+	q.Set("X-Amz-Credential", credential)
+	q.Set("X-Amz-Date", amzDate)
+	q.Set("X-Amz-Expires", strconv.Itoa(expireSecs))
+	q.Set("X-Amz-SignedHeaders", "host")
+	canonicalQuery := q.Encode() // url.Values.Encode() sorts keys
+
+	canonicalHeaders := "host:" + virtualHost + "\n"
+	canonicalURI := "/" + url.PathEscape(key)
+
+	canonicalRequest := strings.Join([]string{
+		"GET",
+		canonicalURI,
+		canonicalQuery,
+		canonicalHeaders,
+		"host",           // signed headers
+		"UNSIGNED-PAYLOAD",
+	}, "\n")
+
+	hashReq := sha256.Sum256([]byte(canonicalRequest))
+	stringToSign := "AWS4-HMAC-SHA256\n" + amzDate + "\n" + credScope + "\n" + hex.EncodeToString(hashReq[:])
+
+	signingKey := hmacSHA256(hmacSHA256(hmacSHA256(hmacSHA256([]byte("AWS4"+dest.Password), dateStamp), region), service), "aws4_request")
+	sig := hex.EncodeToString(hmacSHA256(signingKey, stringToSign))
+
+	finalURL := objectURL + "?" + canonicalQuery + "&X-Amz-Signature=" + sig
+	return finalURL, nil
 }
 
 // ListBucketBackups lists objects in a bucket with an optional prefix filter.

--- a/web/src/views/BackupView.vue
+++ b/web/src/views/BackupView.vue
@@ -245,6 +245,12 @@ async function runBucketBackup() {
 
       const { data: status } = await axios.get(`/api/backup/jobs/${activeJobId}`)
 
+      // Show live upload progress when in uploading stage
+      if (status.stage === 'uploading' && status.uploaded_bytes > 0) {
+        const mb = (status.uploaded_bytes / 1024 / 1024).toFixed(1)
+        bucketStage.value = `Uploading to bucket… ${mb} MB uploaded`
+      }
+
       if (status.status === 'done') {
         clearInterval(progressTimer)
         bucketProgress.value = 100
@@ -543,15 +549,24 @@ async function downloadFromBucket(key: string) {
   if (dlBucketDownloading.value.has(key)) return
   dlBucketDownloading.value = new Set([...dlBucketDownloading.value, key])
   try {
-    const response = await axios.get('/api/backup/bucket-download', {
-      params: { dest_conn_id: dlBucketConnId.value, object_key: key },
-      responseType: 'blob',
+    // Server returns a 302 redirect to a pre-signed S3 URL so the browser
+    // downloads directly from the bucket at full speed — no proxying.
+    const params = new URLSearchParams({
+      dest_conn_id: String(dlBucketConnId.value),
+      object_key: key,
     })
-    downloadBlob(response.data, key.split('/').pop() ?? key)
+    const a = document.createElement('a')
+    a.href = `/api/backup/bucket-download?${params}`
+    a.download = key.split('/').pop() ?? key
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
   } catch (err: any) {
-    toast.error(err?.response?.data?.error || 'Download failed')
+    toast.error('Download failed')
   } finally {
-    dlBucketDownloading.value = new Set([...dlBucketDownloading.value].filter(k => k !== key))
+    setTimeout(() => {
+      dlBucketDownloading.value = new Set([...dlBucketDownloading.value].filter(k => k !== key))
+    }, 1500)
   }
 }
 


### PR DESCRIPTION
## Summary

Fix hidden request download by implementing direct S3 downloads with pre-signed URLs and adding upload progress tracking.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Chore / dependency update

## What Changed

<!-- Bullet points grouped by area: frontend / backend / db / bug fix -->

Backend changes:
- Added stage and uploaded_bytes fields to BackupJob struct for progress tracking
- Modified BackupToBucket to track upload progress with countingReader
- Updated GetBackupJobStatus to return uploaded bytes from atomic counter
- Completely rewrote DownloadFromBucket to use pre-signed URLs instead of proxying
- Added presignedDownloadURL helper function for generating S3 download URLs

Frontend changes:
- Updated downloadFromBucket in BackupView.vue to handle 302 redirects
- Added progress display for bucket uploads showing MB uploaded
- Improved download handling with direct link creation instead of axios blob download

DB changes:
- No database schema changes in this diff

Bug fix:
- Fixed hidden request download by bypassing server proxying for downloads
- Added proper progress tracking for bucket uploads that was previously hidden

## Related Issues

<!-- Link any related issues: Closes #123 -->

## Verification

- [ ] `cd server && go test ./...`
- [ ] `cd web && npm run build`
- [ ] Manual UI verification, if applicable
- [ ] Tested on PostgreSQL / MySQL (if DB changes are included)
- [ ] Tested on SQLite (default local setup)

## Checklist

- [ ] The change is focused and reviewable.
- [ ] New API endpoints are protected with appropriate permission checks.
- [ ] Database migrations are backward-compatible (additive only — no column drops or renames).
- [ ] Error messages are user-friendly and do not leak internal details.
- [ ] Documentation was updated when behavior or configuration changed.
- [ ] No secrets, local databases, logs, or generated build output are committed.
- [ ] Security and permission impact was considered.

## Screenshots

Add screenshots or video for visible UI changes.