### PR TITLE
fix: fix download feature for mariadb

### DIFF
--- a/server/handlers/backup_bucket.go
+++ b/server/handlers/backup_bucket.go
@@ -427,12 +427,13 @@ func uploadToBucket(ctx interface {
 	return uploadToBucketStream(ctx, dest, objectKey, bytes.NewReader(data))
 }
 
-// DownloadFromBucket generates a pre-signed URL and redirects the browser
-// directly to S3-compatible storage, bypassing the server for the data transfer.
-// For multi-GB files this is dramatically faster than proxying through the server.
-// GET /api/backup/bucket-download?dest_conn_id=N&object_key=path/to/file.sql.gz
-func DownloadFromBucket() http.HandlerFunc {
+// PresignDownload returns a short-lived pre-signed download URL for a bucket object.
+// The frontend fetches this endpoint (with auth), then opens the returned URL directly
+// so the browser downloads from OBS/S3 without routing through the app server.
+// GET /api/backup/presign?dest_conn_id=N&object_key=path/to/file.sql.gz
+func PresignDownload() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		destIDStr := r.URL.Query().Get("dest_conn_id")
 		destID, err := strconv.ParseInt(destIDStr, 10, 64)
 		if err != nil || destID == 0 {
@@ -457,8 +458,75 @@ func DownloadFromBucket() http.HandlerFunc {
 			return
 		}
 
-		// Redirect browser directly to S3 — no proxying, full download speed.
-		http.Redirect(w, r, signed, http.StatusFound)
+		json.NewEncoder(w).Encode(map[string]string{"url": signed})
+	}
+}
+
+// DownloadFromBucket proxies a file from S3-compatible storage to the browser.
+// Used as fallback when the bucket is not publicly reachable from the browser.
+// GET /api/backup/bucket-download?dest_conn_id=N&object_key=path/to/file.sql.gz
+func DownloadFromBucket() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		destIDStr := r.URL.Query().Get("dest_conn_id")
+		destID, err := strconv.ParseInt(destIDStr, 10, 64)
+		if err != nil || destID == 0 {
+			http.Error(w, `{"error":"dest_conn_id required"}`, http.StatusBadRequest)
+			return
+		}
+		objectKey := strings.TrimPrefix(r.URL.Query().Get("object_key"), "/")
+		if objectKey == "" {
+			http.Error(w, `{"error":"object_key required"}`, http.StatusBadRequest)
+			return
+		}
+
+		dest, err := fetchBucketConn(destID)
+		if err != nil {
+			http.Error(w, `{"error":"`+err.Error()+`"}`, http.StatusBadRequest)
+			return
+		}
+
+		endpointHost := buildS3Host(dest)
+		scheme := "https"
+		if !dest.SSL {
+			scheme = "http"
+		}
+		bucket := strings.Trim(dest.Bucket, "/")
+		virtualHost := bucket + "." + endpointHost
+		downloadURL := fmt.Sprintf("%s://%s/%s", scheme, virtualHost, url.PathEscape(objectKey))
+
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, downloadURL, nil)
+		if err != nil {
+			http.Error(w, `{"error":"failed to build request: `+err.Error()+`"}`, http.StatusInternalServerError)
+			return
+		}
+
+		payloadHash := sha256.Sum256([]byte{})
+		payloadHashHex := hex.EncodeToString(payloadHash[:])
+		region := objectStorageRegion(dest.Driver, endpointHost)
+		service := objectStorageService(dest.Driver)
+		signObjectStorageRequestFull(req, dest.Username, dest.Password, region, service, payloadHashHex, nil)
+
+		client := &http.Client{Timeout: 4 * time.Hour}
+		resp, err := client.Do(req)
+		if err != nil {
+			http.Error(w, `{"error":"download failed: `+err.Error()+`"}`, http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode >= 400 {
+			http.Error(w, fmt.Sprintf(`{"error":"bucket returned HTTP %d"}`, resp.StatusCode), http.StatusBadGateway)
+			return
+		}
+
+		parts := strings.Split(objectKey, "/")
+		filename := parts[len(parts)-1]
+		w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		if cl := resp.Header.Get("Content-Length"); cl != "" {
+			w.Header().Set("Content-Length", cl)
+		}
+		io.Copy(w, resp.Body)
 	}
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -823,6 +823,13 @@ func registerRoutes(mux *http.ServeMux, cfg *config.Config) {
 		}
 		requireAny(handlers.PermBackupsManage)(handlers.ListBucketBackups())(w, r)
 	})
+	mux.HandleFunc("/api/backup/presign", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		requireAny(handlers.PermBackupsManage)(handlers.PresignDownload())(w, r)
+	})
 	mux.HandleFunc("/api/backup/bucket-download", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.NotFound(w, r)

--- a/web/src/views/BackupView.vue
+++ b/web/src/views/BackupView.vue
@@ -548,21 +548,32 @@ async function loadDlBucketFiles() {
 async function downloadFromBucket(key: string) {
   if (dlBucketDownloading.value.has(key)) return
   dlBucketDownloading.value = new Set([...dlBucketDownloading.value, key])
+  const params = new URLSearchParams({
+    dest_conn_id: String(dlBucketConnId.value),
+    object_key: key,
+  })
+  const filename = key.split('/').pop() ?? key
   try {
-    // Server returns a 302 redirect to a pre-signed S3 URL so the browser
-    // downloads directly from the bucket at full speed — no proxying.
-    const params = new URLSearchParams({
-      dest_conn_id: String(dlBucketConnId.value),
-      object_key: key,
-    })
+    // Try presigned URL first — browser downloads directly from bucket, no proxying.
+    const { data } = await axios.get<{ url: string }>(`/api/backup/presign?${params}`)
     const a = document.createElement('a')
-    a.href = `/api/backup/bucket-download?${params}`
-    a.download = key.split('/').pop() ?? key
+    a.href = data.url
+    a.download = filename
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
-  } catch (err: any) {
-    toast.error('Download failed')
+  } catch {
+    // Fall back to server-proxied download.
+    try {
+      const a = document.createElement('a')
+      a.href = `/api/backup/bucket-download?${params}`
+      a.download = filename
+      document.body.appendChild(a)
+      a.click()
+      document.body.removeChild(a)
+    } catch (err: any) {
+      toast.error('Download failed')
+    }
   } finally {
     setTimeout(() => {
       dlBucketDownloading.value = new Set([...dlBucketDownloading.value].filter(k => k !== key))


### PR DESCRIPTION
## Summary

This PR fixes the download feature for MariaDB by implementing a two-step approach: first attempting direct download from the bucket using pre-signed URLs, with a fallback to server-proxied downloads when direct access isn't possible. The change improves reliability while maintaining download performance.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Chore / dependency update

## What Changed

- **Backend (`server/handlers/backup_bucket.go`)**:
  - Added new `PresignDownload()` function that returns pre-signed URLs as JSON
  - Refactored `DownloadFromBucket()` to serve as a fallback proxy download method
  - Implemented proper error handling and content-type headers for both methods

- **Backend (`server/main.go`)**:
  - Added new route `/api/backup/presign` for the pre-signed URL endpoint

- **Frontend (`web/src/views/BackupView.vue`)**:
  - Updated download logic to first attempt direct download via pre-signed URL
  - Added fallback to server-proxied download if direct download fails
  - Improved error handling and user experience

## Related Issues

<!-- Link any related issues: Closes #123 -->

## Verification

- [ ] `cd server && go test ./...`
- [ ] `cd web && npm run build`
- [ ] Manual UI verification, if applicable
- [ ] Tested on PostgreSQL / MySQL (if DB changes are included)
- [ ] Tested on SQLite (default local setup)

## Checklist

- [ ] The change is focused and reviewable.
- [ ] New API endpoints are protected with appropriate permission checks.
- [ ] Database migrations are backward-compatible (additive only — no column drops or renames).
- [ ] Error messages are user-friendly and do not leak internal details.
- [ ] Documentation was updated when behavior or configuration changed.
- [ ] No secrets, local databases, logs, or generated build output are committed.
- [ ] Security and permission impact was considered.

## Screenshots

Add screenshots or video for visible UI changes.