### PR TITLE
chore: enhance sql panel to run multiple query inside its panel

### DIFF
--- a/web/src/components/database/QueryEditor.vue
+++ b/web/src/components/database/QueryEditor.vue
@@ -27,6 +27,7 @@ let view: EditorView | null = null
 const themeCompartment = new Compartment()
 const completionCompartment = new Compartment()
 
+// Returns selected text if any, otherwise the statement at the cursor position.
 function getActiveSQL(): string {
   if (!view) return props.modelValue
   const state = view.state
@@ -34,6 +35,7 @@ function getActiveSQL(): string {
   if (from !== to) return state.sliceDoc(from, to).trim()
   const full = state.doc.toString()
   const cursor = state.selection.main.head
+  // Split on bare semicolons, respecting single/double-quoted strings
   const stmts: Array<{ from: number; to: number }> = []
   let inSingle = false, inDouble = false, stmtStart = 0
   for (let i = 0; i < full.length; i++) {

--- a/web/src/components/database/SQLPanel.vue
+++ b/web/src/components/database/SQLPanel.vue
@@ -55,6 +55,18 @@ const activeConn = computed(() =>
   props.connId ? connections.value.find(c => c.id === props.connId) ?? null : null
 )
 const selectedDatabase = ref(props.defaultDb ?? '')
+const editorRefs = ref<Record<string, InstanceType<typeof QueryEditor>>>({})
+
+function setEditorRef(tabId: string, el: InstanceType<typeof QueryEditor> | null) {
+  if (el) editorRefs.value[tabId] = el
+  else delete editorRefs.value[tabId]
+}
+
+function getActiveSQLFromEditor(): string {
+  const tab = activeTab.value
+  if (!tab) return ''
+  return editorRefs.value[tab.id]?.getActiveSQL() ?? tab.sql
+}
 
 // ── Tabs ──────────────────────────────────────────────────────────
 interface QueryTab {
@@ -70,17 +82,6 @@ function makeTab(sql = 'SELECT 1;'): QueryTab {
 const tabs = ref<QueryTab[]>([makeTab(props.initialSql || 'SELECT 1;')])
 const activeTabId = ref(tabs.value[0].id)
 const activeTab = computed(() => tabs.value.find(t => t.id === activeTabId.value) ?? tabs.value[0])
-
-// Per-tab editor refs so the Run button can call getActiveSQL() on the current editor
-const editorRefs = ref<Map<string, InstanceType<typeof QueryEditor>>>(new Map())
-function setEditorRef(tabId: string, el: InstanceType<typeof QueryEditor> | null) {
-  if (el) editorRefs.value.set(tabId, el)
-  else editorRefs.value.delete(tabId)
-}
-function getActiveSQLFromEditor(): string {
-  const editor = activeTab.value ? editorRefs.value.get(activeTab.value.id) : null
-  return editor?.getActiveSQL() ?? activeTab.value?.sql ?? ''
-}
 
 function addTab() {
   const t = makeTab()
@@ -321,12 +322,13 @@ async function submitApprovalRequest() {
 // ── Explain ───────────────────────────────────────────────────────
 async function runExplainPlan() {
   if (!props.connId || !activeTab.value?.sql) return
+  const sql = getActiveSQLFromEditor()
   activeTab.value.running = true
   try {
     const { data } = await axios.post(`/api/connections/${props.connId}/explain`, {
-      sql: activeTab.value.sql
+      sql
     })
-    emit('result', { kind: 'explain', data, sql: activeTab.value.sql })
+    emit('result', { kind: 'explain', data, sql })
   } catch (e) {
     setActiveError(readableError(e, { action: 'Explain query', fallback: 'Explain failed' }), activeTab.value.sql)
   } finally {


### PR DESCRIPTION
## Summary

<!-- 1-3 sentences describing what this PR does and why -->
Enhances SQL panel functionality to allow running selected SQL statements rather than executing entire tab content. Adds ability to extract and execute individual queries from multi-query SQL content in the editor.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement to existing feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Chore / dependency update

## What Changed

<!-- Bullet points grouped by area: frontend / backend / db / bug fix -->
### Frontend
- **web/src/components/database/QueryEditor.vue**:
  - Added `getActiveSQL()` function to extract selected text or statement at cursor position
  - Modified run event to include SQL string as payload
  - Exposed `getActiveSQL` method for external access
  - Updated keyboard shortcuts (Ctrl-Enter, Mod-Enter) to pass the active SQL

- **web/src/components/database/SQLPanel.vue**:
  - Added `editorRefs` to track editor instances per tab
  - Implemented `getActiveSQLFromEditor()` to get SQL from active tab's editor
  - Modified `runQuery()` to accept optional `activeSql` parameter
  - Updated run button to pass active SQL from editor to `runQuery()`
  - Added ref binding to track editor instances

## Related Issues

<!-- Link any related issues: Closes #123 -->

## Verification

- [ ] `cd server && go test ./...`
- [ ] `cd web && npm run build`
- [ ] Manual UI verification, if applicable
- [ ] Tested on PostgreSQL / MySQL (if DB changes are included)
- [ ] Tested on SQLite (default local setup)

## Checklist

- [ ] The change is focused and reviewable.
- [ ] New API endpoints are protected with appropriate permission checks.
- [ ] Database migrations are backward-compatible (additive only — no column drops or renames).
- [ ] Error messages are user-friendly and do not leak internal details.
- [ ] Documentation was updated when behavior or configuration changed.
- [ ] No secrets, local databases, logs, or generated build output are committed.
- [ ] Security and permission impact was considered.

## Screenshots

Add screenshots or video for visible UI changes.