### PR TITLE
fix: fix issue to handle multiple queries

### DIFF
--- a/web/src/components/database/SQLPanel.vue
+++ b/web/src/components/database/SQLPanel.vue
@@ -71,6 +71,17 @@ const tabs = ref<QueryTab[]>([makeTab(props.initialSql || 'SELECT 1;')])
 const activeTabId = ref(tabs.value[0].id)
 const activeTab = computed(() => tabs.value.find(t => t.id === activeTabId.value) ?? tabs.value[0])
 
+// Per-tab editor refs so the Run button can call getActiveSQL() on the current editor
+const editorRefs = ref<Map<string, InstanceType<typeof QueryEditor>>>(new Map())
+function setEditorRef(tabId: string, el: InstanceType<typeof QueryEditor> | null) {
+  if (el) editorRefs.value.set(tabId, el)
+  else editorRefs.value.delete(tabId)
+}
+function getActiveSQLFromEditor(): string {
+  const editor = activeTab.value ? editorRefs.value.get(activeTab.value.id) : null
+  return editor?.getActiveSQL() ?? activeTab.value?.sql ?? ''
+}
+
 function addTab() {
   const t = makeTab()
   tabs.value.push(t)
@@ -234,9 +245,11 @@ async function handleApprovalRequired(sql: string, responseData: any) {
   return false
 }
 
-async function runQuery() {
+async function runQuery(sqlOverride?: string) {
   if (!props.connId || !activeTab.value) return
   const tab = activeTab.value
+  const sql = sqlOverride ?? getActiveSQLFromEditor()
+  if (!sql.trim()) return
   const ctrl = new AbortController()
   abortControllers.set(tab.id, ctrl)
   tab.running = true
@@ -245,7 +258,7 @@ async function runQuery() {
   try {
     const { data } = await axios.post<QueryResult>(
       `/api/connections/${props.connId}/query`,
-      { sql: buildParamSQL(tab.sql), database: selectedDatabase.value || undefined },
+      { sql: buildParamSQL(sql), database: selectedDatabase.value || undefined },
       { signal: ctrl.signal }
     )
     emit('result', {
@@ -255,12 +268,12 @@ async function runQuery() {
       duration_ms: data.duration_ms,
       row_count: data.row_count,
       affected_rows: data.affected_rows ?? 0,
-      sql: tab.sql,
+      sql,
       database: selectedDatabase.value || undefined,
     })
     // Record in history
     axios.post(`/api/connections/${props.connId}/history`, {
-      sql: tab.sql, duration_ms: data.duration_ms, row_count: data.row_count,
+      sql, duration_ms: data.duration_ms, row_count: data.row_count,
     }).catch(() => {})
   } catch (e: unknown) {
     const err = e as { code?: string; response?: { data?: { error?: string } } }
@@ -268,20 +281,20 @@ async function runQuery() {
       const responseData = (err as any)?.response?.data
       if (responseData?.approval_required) {
         try {
-          await handleApprovalRequired(tab.sql, responseData)
+          await handleApprovalRequired(sql, responseData)
           return
         } catch (submitErr) {
           tab.error = readableError(submitErr, { action: 'Submit approval request', fallback: 'Failed to submit approval request' })
           tab.notice = ''
           tab.noticeTone = 'error'
-          emit('result', { kind: 'error', error: tab.error, sql: tab.sql })
+          emit('result', { kind: 'error', error: tab.error, sql })
           return
         }
       }
       tab.error = readableError(e, { action: 'Run query', fallback: 'Query failed' })
       tab.notice = ''
       tab.noticeTone = 'error'
-      emit('result', { kind: 'error', error: tab.error, sql: tab.sql })
+      emit('result', { kind: 'error', error: tab.error, sql })
     }
   } finally {
     tab.running = false
@@ -325,9 +338,11 @@ async function runExplainPlan() {
 const streamMode = ref(false)
 let streamAbort: AbortController | null = null
 
-async function runStreamQuery() {
-  if (!props.connId || !activeTab.value?.sql) return
+async function runStreamQuery(sqlOverride?: string) {
+  if (!props.connId || !activeTab.value) return
   const tab = activeTab.value
+  const sql = sqlOverride ?? getActiveSQLFromEditor()
+  if (!sql.trim()) return
   tab.running = true
   const cols: string[] = []
   const rows: unknown[][] = []
@@ -338,7 +353,7 @@ async function runStreamQuery() {
     const resp = await fetch(`/api/connections/${props.connId}/query/stream`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ sql: tab.sql, database: selectedDatabase.value || undefined }),
+      body: JSON.stringify({ sql, database: selectedDatabase.value || undefined }),
       signal: streamAbort.signal,
     })
     if (!resp.ok) throw new Error(await readableFetchError(resp, 'Stream query failed'))
@@ -611,7 +626,7 @@ defineExpose({ loadSQL, currentSQL, exportCurrentResult })
         <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>
         Stop
       </button>
-      <button v-else class="base-btn base-btn--primary base-btn--sm" :disabled="!connId || !activeTab?.sql.trim()" @click="streamMode ? runStreamQuery() : runQuery()">
+      <button v-else class="base-btn base-btn--primary base-btn--sm" :disabled="!connId || !activeTab?.sql.trim()" @click="streamMode ? runStreamQuery(getActiveSQLFromEditor()) : runQuery(getActiveSQLFromEditor())">
         <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
         {{ streamMode ? 'Stream' : 'Run' }}
       </button>
@@ -637,11 +652,12 @@ defineExpose({ loadSQL, currentSQL, exportCurrentResult })
     <template v-for="tab in tabs" :key="tab.id">
       <div v-show="tab.id === activeTabId" style="flex:1;min-height:0;display:flex;flex-direction:column;">
         <QueryEditor
+          :ref="(el: any) => setEditorRef(tab.id, el)"
           v-model="tab.sql"
           :dark-mode="darkMode"
           :schema-completion="schemaCompletion"
           placeholder="Write SQL here… (Cmd/Ctrl+Enter run, Cmd/Ctrl+Space suggest)"
-          @run="runQuery"
+          @run="(sql) => streamMode ? runStreamQuery(sql) : runQuery(sql)"
         />
       </div>
     </template>


### PR DESCRIPTION
## Summary

<!-- Fixed issue with handling multiple queries in SQLPanel by getting SQL directly from editor instead of tab state -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Chore / dependency update

## What Changed

<!-- Bullet points grouped by area: frontend / backend / db / bug fix -->

- **Frontend**: Modified `web/src/components/database/SQLPanel.vue` to properly handle multiple query tabs by:
  - Adding editor references management with editorRefs Map
  - Adding setEditorRef and getActiveSQLFromEditor helper functions
  - Updating runQuery and runStreamQuery to accept optional sqlOverride parameter
  - Modifying button click handlers to pass current SQL from editor
  - Updating QueryEditor component ref and event handlers

## Related Issues

<!-- Link any related issues: Closes #123 -->

## Verification

- [ ] `cd server && go test ./...`
- [ ] `cd web && npm run build`
- [ ] Manual UI verification, if applicable
- [ ] Tested on PostgreSQL / MySQL (if DB changes are included)
- [ ] Tested on SQLite (default local setup)

## Checklist

- [ ] The change is focused and reviewable.
- [ ] New API endpoints are protected with appropriate permission checks.
- [ ] Database migrations are backward-compatible (additive only — no column drops or renames).
- [ ] Error messages are user-friendly and do not leak internal details.
- [ ] Documentation was updated when behavior or configuration changed.
- [ ] No secrets, local databases, logs, or generated build output are committed.
- [ ] Security and permission impact was considered.

## Screenshots

Add screenshots or video for visible UI changes.