### PR TITLE
fix: fix issue wrong connection

### DIFF
--- a/server/handlers/ai.go
+++ b/server/handlers/ai.go
@@ -363,7 +363,8 @@ func AIAnalytics() http.HandlerFunc {
 
 		result, err := executeAnalyticsQuery(r.Context(), dbConn, plan.SQL)
 		if err != nil {
-			http.Error(w, jsonError(sanitizeDBError(err)), http.StatusBadRequest)
+			msg := sanitizeDBError(err)
+			http.Error(w, jsonError(msg), dbErrorStatus(msg))
 			return
 		}
 

--- a/server/handlers/analytics_dashboards.go
+++ b/server/handlers/analytics_dashboards.go
@@ -341,7 +341,8 @@ func PreviewAnalyticsDashboardQuery() http.HandlerFunc {
 		}
 		result, err := executeAnalyticsQuery(r.Context(), dbConn, sqlText)
 		if err != nil {
-			http.Error(w, jsonError(sanitizeDBError(err)), http.StatusBadRequest)
+			msg := sanitizeDBError(err)
+			http.Error(w, jsonError(msg), dbErrorStatus(msg))
 			return
 		}
 		if len(result.Rows) > 100 {

--- a/server/handlers/change_sets.go
+++ b/server/handlers/change_sets.go
@@ -577,8 +577,9 @@ func ExecuteChangeSet() http.HandlerFunc {
 		res, execErr := db.ExecContext(r.Context(), cs.Statement)
 		durationMs := time.Since(start).Milliseconds()
 		if execErr != nil {
-			markChangeSetExecution(id, QueryApprovalStatusFailed, sanitizeDBError(execErr))
-			http.Error(w, jsonError(sanitizeDBError(execErr)), http.StatusBadRequest)
+			msg := sanitizeDBError(execErr)
+			markChangeSetExecution(id, QueryApprovalStatusFailed, msg)
+			http.Error(w, jsonError(msg), dbErrorStatus(msg))
 			return
 		}
 

--- a/server/handlers/data_scripts.go
+++ b/server/handlers/data_scripts.go
@@ -774,13 +774,15 @@ func ExecuteDataChangePlan() http.HandlerFunc {
 					TargetUserIDs: []int64{plan.CreatorID},
 					Payload:       map[string]any{"error": sanitizeDBError(execErr)},
 				})
-				http.Error(w, jsonError(sanitizeDBError(execErr)), http.StatusBadRequest)
+				execMsg := sanitizeDBError(execErr)
+				http.Error(w, jsonError(execMsg), dbErrorStatus(execMsg))
 				return
 			}
 			affected += n
 		}
 		if err := tx.Commit(); err != nil {
-			markDataPlanExecution(id, QueryApprovalStatusFailed, sanitizeDBError(err))
+			commitMsg := sanitizeDBError(err)
+			markDataPlanExecution(id, QueryApprovalStatusFailed, commitMsg)
 			EmitNotification(NotificationEventInput{
 				EventType:     "data_script.failed",
 				Category:      "data_script",
@@ -792,9 +794,9 @@ func ExecuteDataChangePlan() http.HandlerFunc {
 				ConnectionID:  plan.ConnID,
 				ActorUserID:   userID,
 				TargetUserIDs: []int64{plan.CreatorID},
-				Payload:       map[string]any{"error": sanitizeDBError(err)},
+				Payload:       map[string]any{"error": commitMsg},
 			})
-			http.Error(w, jsonError(sanitizeDBError(err)), http.StatusBadRequest)
+			http.Error(w, jsonError(commitMsg), dbErrorStatus(commitMsg))
 			return
 		}
 

--- a/server/handlers/query.go
+++ b/server/handlers/query.go
@@ -45,6 +45,20 @@ func sanitizeDBError(err error) string {
 	return msg
 }
 
+// dbErrorStatus returns the appropriate HTTP status for a sanitized DB error message.
+// Connection-level failures are infrastructure errors (502); permission/syntax errors
+// are client errors (403/400).
+func dbErrorStatus(sanitized string) int {
+	switch sanitized {
+	case "database connection error":
+		return http.StatusBadGateway
+	case "permission denied":
+		return http.StatusForbidden
+	default:
+		return http.StatusBadRequest
+	}
+}
+
 func ExecuteQuery() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -155,7 +169,8 @@ func ExecuteQuery() http.HandlerFunc {
 				rows, err = db.QueryContext(r.Context(), req.SQL)
 			}
 			if err != nil {
-				http.Error(w, jsonError(sanitizeDBError(err)), http.StatusBadRequest)
+				msg := sanitizeDBError(err)
+				http.Error(w, jsonError(msg), dbErrorStatus(msg))
 				return
 			}
 			defer rows.Close()
@@ -189,14 +204,16 @@ func ExecuteQuery() http.HandlerFunc {
 			if hasTx {
 				res, err := activeTx.ExecContext(r.Context(), req.SQL)
 				if err != nil {
-					http.Error(w, jsonError(sanitizeDBError(err)), http.StatusBadRequest)
+					msg := sanitizeDBError(err)
+					http.Error(w, jsonError(msg), dbErrorStatus(msg))
 					return
 				}
 				affected, _ = res.RowsAffected()
 			} else {
 				res, err := db.ExecContext(r.Context(), req.SQL)
 				if err != nil {
-					http.Error(w, jsonError(sanitizeDBError(err)), http.StatusBadRequest)
+					msg := sanitizeDBError(err)
+					http.Error(w, jsonError(msg), dbErrorStatus(msg))
 					return
 				}
 				affected, _ = res.RowsAffected()

--- a/server/handlers/workflow_approval.go
+++ b/server/handlers/workflow_approval.go
@@ -886,7 +886,8 @@ func ExecuteApprovalRequest() http.HandlerFunc {
 				TargetUserIDs: []int64{req.CreatorID},
 				Payload:       map[string]any{"error": sanitizeDBError(execErr)},
 			})
-			http.Error(w, jsonError(sanitizeDBError(execErr)), http.StatusBadRequest)
+			msg := sanitizeDBError(execErr)
+			http.Error(w, jsonError(msg), dbErrorStatus(msg))
 			return
 		}
 


### PR DESCRIPTION
## Summary
This PR fixes incorrect HTTP status codes returned for database connection errors. It properly distinguishes between connection-level failures (502), permission errors (403), and other database errors (400) instead of always returning 400.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Enhancement to existing feature
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Chore / dependency update

## What Changed
- Backend: Added `dbErrorStatus()` function in server/handlers/query.go to map different database error types to appropriate HTTP status codes
- Backend: Updated error handling in multiple handlers (ai.go, analytics_dashboards.go, change_sets.go, data_scripts.go, query.go, workflow_approval.go) to use the new status code mapping
- Bug fix: Changed handling of database connection errors to return 502 Bad Gateway instead of 400 Bad Request
- Bug fix: Changed handling of permission errors to return 403 Forbidden instead of 400 Bad Request

## Related Issues
<!-- Link any related issues: Closes #123 -->

## Verification
- [ ] `cd server && go test ./...`
- [ ] `cd web && npm run build`
- [ ] Manual UI verification, if applicable
- [ ] Tested on PostgreSQL / MySQL (if DB changes are included)
- [ ] Tested on SQLite (default local setup)

## Checklist
- [ ] The change is focused and reviewable.
- [ ] New API endpoints are protected with appropriate permission checks.
- [ ] Database migrations are backward-compatible (additive only — no column drops or renames).
- [ ] Error messages are user-friendly and do not leak internal details.
- [ ] Documentation was updated when behavior or configuration changed.
- [ ] No secrets, local databases, logs, or generated build output are committed.
- [ ] Security and permission impact was considered.

## Screenshots
Add screenshots or video for visible UI changes.